### PR TITLE
35: Updated Accordion and AccordionItem logic

### DIFF
--- a/src/lib/components/Accordion/Accordion.js
+++ b/src/lib/components/Accordion/Accordion.js
@@ -1,34 +1,46 @@
 import React from 'react';
-import AccordionItem from './AccordionItem';
+import PropTypes from 'prop-types';
 import './Accordion.css';
 
 class Accordion extends React.Component {
+  constructor(props) {
+    super(props);
+    this.toggleSection = this.toggleSection.bind(this);
+    this.state = {
+      open: props.selected,
+    };
+  }
+
+  toggleSection(index) {
+    this.setState({ open: this.state.open === index ? null : index });
+  }
+
   render() {
+    const accordionItems = React.Children.map(this.props.children,
+      (child, index) => React.cloneElement(child, {
+        index,
+        isOpen: this.state.open === index,
+        onClick: this.toggleSection,
+      }),
+    );
+
     return (
       <aside className="p-accordion" role="tablist">
         <ul className="p-accordion__list">
-          <AccordionItem title="Title of Item 1">
-            <p>Lorem Ipsum has been the industrys standard dummy text ever since
-            the 1500s, when an unknown printer took a galley of type and
-            scrambled it to make a type specimen book.
-            </p>
-          </AccordionItem>
-          <AccordionItem title="Title of Item 2">
-            <p>Lorem Ipsum has been the industrys standard dummy text ever since
-            the 1500s, when an unknown printer took a galley of type and
-            scrambled it to make a type specimen book.
-            </p>
-          </AccordionItem>
-          <AccordionItem title="Title of Item 3">
-            <p>Lorem Ipsum has been the industrys standard dummy text ever since
-            the 1500s, when an unknown printer took a galley of type and
-            scrambled it to make a type specimen book.
-            </p>
-          </AccordionItem>
+          { accordionItems }
         </ul>
       </aside>
     );
   }
 }
+
+Accordion.defaultProps = {
+  selected: null,
+};
+
+Accordion.propTypes = {
+  children: PropTypes.node.isRequired,
+  selected: PropTypes.number,
+};
 
 export default Accordion;

--- a/src/lib/components/Accordion/Accordion.scss
+++ b/src/lib/components/Accordion/Accordion.scss
@@ -1,3 +1,4 @@
 @import 'vanilla-framework/scss/base';
 @import 'vanilla-framework/scss/patterns_accordion';
+@include vf-base;
 @include vf-p-accordion;

--- a/src/lib/components/Accordion/AccordionItem.js
+++ b/src/lib/components/Accordion/AccordionItem.js
@@ -5,15 +5,11 @@ import './Accordion.css';
 class AccordionItem extends React.Component {
   constructor() {
     super();
-    this.accordionItemToggle = this.accordionItemToggle.bind(this);
-    this.state = {
-      hidden: true,
-    };
+    this.onClick = this.onClick.bind(this);
   }
 
-  accordionItemToggle() {
-    const currentState = this.state.hidden;
-    this.setState({ hidden: !currentState });
+  onClick() {
+    this.props.onClick(this.props.index);
   }
 
   render() {
@@ -24,9 +20,9 @@ class AccordionItem extends React.Component {
           id="status-tab"
           role="tab"
           aria-controls="#status"
-          aria-expanded={!this.state.hidden}
-          onClick={() => this.accordionItemToggle(this)}
-          onKeyDown={() => this.accordionItemToggle(this)}
+          aria-expanded={this.props.isOpen}
+          onClick={this.onClick}
+          onKeyDown={this.onClick}
         >
           { this.props.title }
         </button>
@@ -34,7 +30,7 @@ class AccordionItem extends React.Component {
           className="p-accordion__panel"
           id="status"
           role="tabpanel"
-          aria-hidden={this.state.hidden}
+          aria-hidden={!this.props.isOpen}
           aria-labelledby="status-tab"
         >
           { this.props.children }
@@ -44,9 +40,18 @@ class AccordionItem extends React.Component {
   }
 }
 
+AccordionItem.defaultProps = {
+  index: 0,
+  isOpen: false,
+  onClick: () => 1,
+};
+
 AccordionItem.propTypes = {
+  index: PropTypes.number,
   title: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
+  isOpen: PropTypes.bool,
+  onClick: PropTypes.func,
 };
 
 export default AccordionItem;


### PR DESCRIPTION
# Done
- Updated Accordion and AccordionItem logic to allow single-item-open behaviour
- Fixed bug where Accordion was hard-coded with children
- Fixed Accordion styling

# QA
- Pull code
- Run `yarn clean`, `yarn build` and `yarn serve`
- Run `yarn lint` and `yarn test` and ensure there are no linting or testing errors
- Verify the Accordion component has single-item-only behaviour on Storybook

# Fixes
Fixes #35, fixes #43 
