### PR TITLE
Reduced Accordion CSS to only relevant files

### DIFF
--- a/src/lib/components/Accordion/Accordion.scss
+++ b/src/lib/components/Accordion/Accordion.scss
@@ -1,4 +1,9 @@
 @import 'vanilla-framework/scss/base';
 @import 'vanilla-framework/scss/patterns_accordion';
-@include vf-base;
+@include vf-b-typography;
+@include vf-b-button;
 @include vf-p-accordion;
+
+.p-accordion__panel > :first-child {
+  margin-top: 0;
+}


### PR DESCRIPTION
# Done
- Fixed the Accordion scss so it doesn't include the whole base Vanilla file
- This should fix styling throughout Storybook

# QA
- Pull code
- Run `yarn clean` and `yarn serve` and navigate to http://localhost:6006/
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Verify the Accordion component still looks okay in Storybook, and that styling throughout Storybook looks good