### PR TITLE
Deconstruct state in components rather than long hand references

### DIFF
--- a/src/lib/components/Accordion/Accordion.js
+++ b/src/lib/components/Accordion/Accordion.js
@@ -16,10 +16,11 @@ class Accordion extends React.Component {
   }
 
   render() {
+    const { open } = this.state;
     const accordionItems = React.Children.map(this.props.children,
       (child, index) => React.cloneElement(child, {
         index,
-        isOpen: this.state.open === index,
+        isOpen: open === index,
         onClick: this.toggleSection,
       }),
     );

--- a/src/lib/components/Switch/Switch.js
+++ b/src/lib/components/Switch/Switch.js
@@ -12,11 +12,12 @@ class Switch extends React.Component {
   }
 
   switchToggle() {
-    const currentState = this.state.checked;
-    this.setState({ checked: !currentState });
+    const { checked } = this.state;
+    this.setState({ checked: !checked });
   }
 
   render() {
+    const { checked } = this.state;
     return (
       <span>
         <label id="switch-on-label" htmlFor="switch-on">{ this.props.label }
@@ -25,7 +26,7 @@ class Switch extends React.Component {
             className="p-switch"
             type="button"
             role="switch"
-            aria-checked={this.state.checked}
+            aria-checked={checked}
             aria-labelledby="switch-on-label"
             onClick={() => this.switchToggle(this)}
           >


### PR DESCRIPTION
## Done

Deconstruct state in components rather than long hand references. This is a cleaner (and minimally faster) way to reference state.

## QA

- Pull code
- Run `npm test`
- Ensure no errors
