### PR TITLE
55: Change travis.yml to build and deploy storybook to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,14 @@ cache:
   directories:
   - node_modules
 before_script:
-  - npm run build-css
-
+  - yarn build-css
 script:
-  - npm test
-  - npm run build
+  - yarn test
+  - yarn build-storybook
 deploy:
   provider: pages
   skip_cleanup: true
   github_token: $github_token
-  local_dir: build
+  local_dir: storybook-static
   on:
     branch: master


### PR DESCRIPTION
## Done
- Updated the travis.yml to use yarn, and to run build-storybook instead of build

## QA
- Add your forked repo to [Travis CI](https://travis-ci.org) if you haven't already, and make sure you set up a github token with the correct permissions (call it github_token on the TravisCI dashboard)
- Set GitHub Pages of your repo to gh-branch
- Either pull code into your forked master branch temporarily, or change the `deploy: on: branch:` section of the travis.yml file from master to whatever branch you pull the code into
- Run a Travis CI build of your selected repo/branch and wait for it to deploy
- Navigate to https://<your_github_domain>/vanilla-framework-react/ and ensure that the React Storybook is being served

## Issues
Fixes #55 