### PR TITLE
60: Add Image and InlineImages components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export { default as CodeBlock } from './lib/components/CodeBlock/CodeBlock';
 export { default as CodeSnippet } from './lib/components/CodeSnippet/CodeSnippet';
 export { default as Footer } from './lib/components/Footer/Footer';
 export { default as HeadingIcon } from './lib/components/HeadingIcon/HeadingIcon';
+export { default as Image } from './lib/components/Image/Image';
 export { default as Link } from './lib/components/Link/Link';
 export { default as List } from './lib/components/List/List';
 export { default as SteppedList } from './lib/components/SteppedList/SteppedList';

--- a/src/lib/components/Image/Image.js
+++ b/src/lib/components/Image/Image.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Image.css';
+
+const Image = (props) => {
+  let classArray = [];
+
+  if (props.bordered) {
+    classArray = [...classArray, 'p-image--bordered'];
+  }
+  if (props.shadowed) {
+    classArray = [...classArray, 'p-image--shadowed'];
+  }
+
+  const classString = classArray.join(' ');
+
+  return <img className={classString} src={props.src} alt={props.alt} />;
+};
+
+Image.defaultProps = {
+  alt: '',
+  bordered: false,
+  shadowed: false,
+};
+
+Image.propTypes = {
+  src: PropTypes.string.isRequired,
+  alt: PropTypes.string,
+  bordered: PropTypes.bool,
+  shadowed: PropTypes.bool,
+};
+
+export default Image;

--- a/src/lib/components/Image/Image.scss
+++ b/src/lib/components/Image/Image.scss
@@ -1,0 +1,4 @@
+@import 'vanilla-framework/scss/base';
+@import 'vanilla-framework/scss/patterns_image';
+@include vf-b-media;
+@include vf-p-image;

--- a/src/lib/components/Image/Image.stories.js
+++ b/src/lib/components/Image/Image.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import Image from './Image';
+
+storiesOf('Image', module)
+  .add('Default',
+    withInfo('Default Image component.')(() => (
+      <Image src="http://placekitten.com/g/300/300" alt="" />),
+    ),
+  )
+  .add('Bordered',
+    withInfo('Bordered Image component.')(() => (
+      <Image bordered src="http://placekitten.com/g/300/300" alt="" />),
+    ),
+  )
+  .add('Shadowed',
+    withInfo('Image component with drop-shadow.')(() => (
+      <Image shadowed src="http://placekitten.com/g/300/300" alt="" />),
+    ),
+  )
+  .add('Bordered and shadowed',
+    withInfo('Image component with both border and drop-shadow.')(() => (
+      <Image bordered shadowed src="http://placekitten.com/g/300/300" alt="" />),
+    ),
+  );

--- a/src/lib/components/Image/Image.test.js
+++ b/src/lib/components/Image/Image.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import Image from './Image';
+
+describe('Image component', () => {
+  it('should render a default Image correctly', () => {
+    const image = ReactTestRenderer.create(
+      <Image src="http://placekitten.com/g/300/300" alt="" />);
+    const json = image.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render bordered prop correctly', () => {
+    const image = ReactTestRenderer.create(
+      <Image bordered src="http://placekitten.com/g/300/300" alt="" />);
+    const json = image.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render shadowed prop correctly', () => {
+    const image = ReactTestRenderer.create(
+      <Image shadowed src="http://placekitten.com/g/300/300" alt="" />);
+    const json = image.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render both bordered and shadowed props correctly', () => {
+    const image = ReactTestRenderer.create(
+      <Image bordered shadowed src="http://placekitten.com/g/300/300" alt="" />);
+    const json = image.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/Image/__snapshots__/Image.test.js.snap
+++ b/src/lib/components/Image/__snapshots__/Image.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Image component should render a default Image correctly 1`] = `
+<img
+  alt=""
+  className=""
+  src="http://placekitten.com/g/300/300"
+/>
+`;
+
+exports[`Image component should render bordered prop correctly 1`] = `
+<img
+  alt=""
+  className="p-image--bordered"
+  src="http://placekitten.com/g/300/300"
+/>
+`;
+
+exports[`Image component should render both bordered and shadowed props correctly 1`] = `
+<img
+  alt=""
+  className="p-image--bordered p-image--shadowed"
+  src="http://placekitten.com/g/300/300"
+/>
+`;
+
+exports[`Image component should render shadowed prop correctly 1`] = `
+<img
+  alt=""
+  className="p-image--shadowed"
+  src="http://placekitten.com/g/300/300"
+/>
+`;

--- a/src/lib/components/InlineImages/InlineImages.js
+++ b/src/lib/components/InlineImages/InlineImages.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './InlineImages.css';
+
+const InlineImages = (props) => {
+  const images = React.Children.map(props.children, child => (
+    <li className="p-inline-images__item">
+      {child}
+    </li>),
+  );
+
+  return (
+    <ul className="p-inline-images">
+      {images}
+    </ul>
+  );
+};
+
+InlineImages.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.element),
+  ]).isRequired,
+};
+
+export default InlineImages;

--- a/src/lib/components/InlineImages/InlineImages.scss
+++ b/src/lib/components/InlineImages/InlineImages.scss
@@ -1,0 +1,6 @@
+@import 'vanilla-framework/scss/base';
+@import 'vanilla-framework/scss/patterns_inline-images';
+@import 'vanilla-framework/scss/utilities_clearfix';
+@include vf-b-media;
+@include vf-p-inline-images;
+@include vf-u-clearfix;

--- a/src/lib/components/InlineImages/InlineImages.stories.js
+++ b/src/lib/components/InlineImages/InlineImages.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import InlineImages from './InlineImages';
+import Image from '../Image/Image';
+
+storiesOf('Inline Images', module)
+  .add('Default',
+    withInfo("The InlineImages component can be used to showcase a group of related images, such as a group of customer or partner logos. Vanilla's Image components and <img> tags are accepted children.")(() => (
+      <InlineImages>
+        <Image bordered src="http://placekitten.com/g/200/200" alt="" />
+        <Image bordered src="http://placekitten.com/g/400/400" alt="" />
+        <Image bordered src="http://placekitten.com/g/300/300" alt="" />
+        <Image bordered src="http://placekitten.com/g/500/500" alt="" />
+        <Image bordered src="http://placekitten.com/g/800/800" alt="" />
+        <img src="http://placekitten.com/g/700/700" alt="" />
+      </InlineImages>),
+    ),
+  );

--- a/src/lib/components/InlineImages/InlineImages.test.js
+++ b/src/lib/components/InlineImages/InlineImages.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import InlineImages from './InlineImages';
+import Image from '../Image/Image';
+
+describe('InlineImages component', () => {
+  it('should render the InlineImages component correctly', () => {
+    const inlineImages = ReactTestRenderer.create(
+      <InlineImages>
+        <Image bordered src="http://placekitten.com/g/200/200" alt="" />
+        <Image bordered src="http://placekitten.com/g/400/400" alt="" />
+        <Image bordered src="http://placekitten.com/g/300/300" alt="" />
+        <Image bordered src="http://placekitten.com/g/500/500" alt="" />
+        <Image bordered src="http://placekitten.com/g/800/800" alt="" />
+        <Image bordered src="http://placekitten.com/g/700/700" alt="" />
+      </InlineImages>);
+    const json = inlineImages.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/InlineImages/__snapshots__/InlineImages.test.js.snap
+++ b/src/lib/components/InlineImages/__snapshots__/InlineImages.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InlineImages component should render the InlineImages component correctly 1`] = `
+<ul
+  className="p-inline-images"
+>
+  <li
+    className="p-inline-images__item"
+  >
+    <img
+      alt=""
+      className="p-image--bordered"
+      src="http://placekitten.com/g/200/200"
+    />
+  </li>
+  <li
+    className="p-inline-images__item"
+  >
+    <img
+      alt=""
+      className="p-image--bordered"
+      src="http://placekitten.com/g/400/400"
+    />
+  </li>
+  <li
+    className="p-inline-images__item"
+  >
+    <img
+      alt=""
+      className="p-image--bordered"
+      src="http://placekitten.com/g/300/300"
+    />
+  </li>
+  <li
+    className="p-inline-images__item"
+  >
+    <img
+      alt=""
+      className="p-image--bordered"
+      src="http://placekitten.com/g/500/500"
+    />
+  </li>
+  <li
+    className="p-inline-images__item"
+  >
+    <img
+      alt=""
+      className="p-image--bordered"
+      src="http://placekitten.com/g/800/800"
+    />
+  </li>
+  <li
+    className="p-inline-images__item"
+  >
+    <img
+      alt=""
+      className="p-image--bordered"
+      src="http://placekitten.com/g/700/700"
+    />
+  </li>
+</ul>
+`;


### PR DESCRIPTION
# Done
- Added [Image](https://docs.vanillaframework.io/en/patterns/images) and [InlineImages](https://docs.vanillaframework.io/en/patterns/inline-images) component
- Includes Default, Shadowed, Bordered, Bordered + Shadowed subtypes for Image, and Default for InlineImages
- Added stories to Storybook
- Added snapshot tests

# QA
- Pull code
- Run `yarn clean` and `yarn serve` and navigate to http://localhost:6006/
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Verify the Image and InlineImages components in Storybook match the Vanilla docs

# Fixes
Fixes #60 