### PR TITLE
59: Add Strip component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,4 +9,5 @@ export { default as Image } from './lib/components/Image/Image';
 export { default as Link } from './lib/components/Link/Link';
 export { default as List } from './lib/components/List/List';
 export { default as SteppedList } from './lib/components/SteppedList/SteppedList';
+export { default as Strip } from './lib/components/Strip/Strip';
 export { default as Switch } from './lib/components/Switch/Switch';

--- a/src/lib/components/Strip/Column.js
+++ b/src/lib/components/Strip/Column.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Strip.css';
+
+const Column = (props) => {
+  if (props.size < 1 || props.size > 12) {
+    return new Error('Column component must have size between 1 and 12');
+  }
+  return (
+    <div className={`col-${props.size}`} style={props.style}>
+      {props.children}
+    </div>
+  );
+};
+
+Column.defaultProps = {
+  style: {},
+  size: 12,
+};
+
+Column.propTypes = {
+  children: PropTypes.node.isRequired,
+  size: PropTypes.number,
+  style: PropTypes.object,
+};
+
+export default Column;

--- a/src/lib/components/Strip/Row.js
+++ b/src/lib/components/Strip/Row.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Strip.css';
+
+const Row = props => (
+  <div className="row" style={props.style}>
+    {props.children}
+  </div>
+);
+
+Row.defaultProps = {
+  style: {},
+};
+
+Row.propTypes = {
+  children: PropTypes.node.isRequired,
+  style: PropTypes.object,
+};
+
+export default Row;

--- a/src/lib/components/Strip/Strip.js
+++ b/src/lib/components/Strip/Strip.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Strip.css';
+
+const Strip = (props) => {
+  let classArray = [];
+  let style = Object.assign({}, props.style);
+  const {
+    colour, image, bordered, padding, children,
+  } = props;
+
+  if (colour) {
+    classArray = [...classArray, `p-strip--${props.colour}`];
+  }
+
+  if (image.src) {
+    const imageColour = `is-${image.colour}`;
+    classArray = [...classArray, 'p-strip--image', imageColour];
+    style = Object.assign(
+      style, { backgroundImage: `url(${image.src})` },
+    );
+  }
+
+  if (bordered) {
+    classArray = [...classArray, 'is-bordered'];
+  }
+
+  if (padding) {
+    classArray = [...classArray, `is-${padding}`];
+  }
+
+  const classString = classArray.join(' ');
+
+  return (
+    <section
+      className={classString}
+      style={style}
+    >
+      {children}
+    </section>
+  );
+};
+
+Strip.defaultProps = {
+  colour: 'light',
+  bordered: false,
+  padding: null,
+  image: {
+    src: '',
+    colour: 'dark',
+  },
+  style: {},
+};
+
+Strip.propTypes = {
+  children: PropTypes.node.isRequired,
+  colour: PropTypes.oneOf(['light', 'dark', 'accent']),
+  image: PropTypes.shape({
+    src: PropTypes.string,
+    colour: PropTypes.oneOf(['light', 'dark']),
+  }),
+  bordered: PropTypes.bool,
+  padding: PropTypes.oneOf(['shallow', 'deep']),
+  style: PropTypes.object,
+};
+
+export default Strip;

--- a/src/lib/components/Strip/Strip.scss
+++ b/src/lib/components/Strip/Strip.scss
@@ -1,0 +1,9 @@
+@import 'vanilla-framework/scss/base';
+@import 'vanilla-framework/scss/patterns_strip';
+@import 'vanilla-framework/scss/patterns_grid';
+@import 'vanilla-framework/scss/grid/shelves-grid';
+@include vf-b-typography;
+@include vf-b-vertical-spacing;
+@include vf-p-strip;
+@include vf-p-grid;
+@include vf-p-grid-modifications;

--- a/src/lib/components/Strip/Strip.stories.js
+++ b/src/lib/components/Strip/Strip.stories.js
@@ -1,0 +1,176 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import Strip from './Strip';
+import Row from './Row';
+import Column from './Column';
+import Button from '../Button/Button';
+import Image from '../Image/Image';
+
+storiesOf('Strip', module)
+  .add('Light',
+    withInfo('The Strip component provides a full width container in which to wrap Row components. The default colour is "light".')(() => (
+      <div style={{ maxWidth: '1030px' }}>
+        <Strip>
+          <Row>
+            <p>This is a light Strip</p>
+          </Row>
+        </Strip>
+      </div>),
+    ),
+  )
+
+  .add('Dark',
+    withInfo('The Strip component provides a full width container in which to wrap Row components. An alternative colour is "dark".')(() => (
+      <div style={{ maxWidth: '1030px' }}>
+        <Strip colour="dark">
+          <Row>
+            <p>This is a dark Strip</p>
+          </Row>
+        </Strip>
+      </div>),
+    ),
+  )
+
+  .add('Accent',
+    withInfo('The purpose of the "accent" colour is to display content with a highlighted site accent style.')(() => (
+      <div style={{ maxWidth: '1030px' }}>
+        <Strip colour="accent">
+          <Row>
+            <p>This is an accented Strip</p>
+          </Row>
+        </Strip>
+      </div>),
+    ),
+  )
+
+  .add('Image',
+    withInfo('The "image" prop allows for an image to appear as the background on a Strip. The image prop object can also be described with a "colour" key (with light or dark value). This will then override the text colour to ensure it remains visible.')(() => (
+      <div style={{ maxWidth: '1030px' }}>
+        <Strip image={{
+          src: 'https://assets.ubuntu.com/v1/974c4e8c-background-origami.png?w=600',
+          colour: 'light',
+          }}
+        >
+          <Row>
+            <p>This is an image Strip that has a light image</p>
+          </Row>
+        </Strip>
+        <Strip image={{
+          src: 'https://assets.ubuntu.com/v1/ab1a7e82-background.png?w=600',
+          colour: 'dark',
+          }}
+        >
+          <Row>
+            <p>This is an image Strip that has a dark image</p>
+          </Row>
+        </Strip>
+      </div>),
+    ),
+  )
+
+  .add('Bordered',
+    withInfo('The "bordered" prop is used to add a dividing border at the bottom of the Strip. Note: This should be used when two Strips of the same type are used after each other.')(() => (
+      <div style={{ maxWidth: '1030px' }}>
+        <Strip bordered>
+          <Row>
+            <p>This is a bordered Strip</p>
+          </Row>
+        </Strip>
+      </div>),
+    ),
+  )
+
+  .add('Shallow',
+    withInfo('The padding prop with value "shallow" gives the Strip smaller vertical padding.')(() => (
+      <div style={{ maxWidth: '1030px' }}>
+        <Strip colour="accent" padding="shallow">
+          <Row>
+            <p>This is a shallow Strip</p>
+          </Row>
+        </Strip>
+      </div>),
+    ),
+  )
+
+  .add('Deep',
+    withInfo('The padding prop with value "deep" gives the Strip larger vertical padding.')(() => (
+      <div style={{ maxWidth: '1030px' }}>
+        <Strip colour="accent" padding="deep">
+          <Row>
+            <p>This is a deep Strip</p>
+          </Row>
+        </Strip>
+      </div>),
+    ),
+  )
+
+  .add('Columns',
+    withInfo('The Row component accepts Column components as children. Vanilla uses a 12 column grid, so the sum of all column sizes must be 12. The default size is 12.')(() => {
+      const style = { border: '1px solid #cdcdcd', textAlign: 'center' };
+      return (
+        <div style={{ maxWidth: '1030px' }}>
+          <Strip>
+            <Row>
+              <Column size={6} style={style}>
+                6 columns
+              </Column>
+              <Column size={2} style={style}>
+                2 columns
+              </Column>
+              <Column size={4} style={style}>
+                4 columns
+              </Column>
+            </Row>
+            <Row>
+              <Column size={3} style={style}>
+                3 columns
+              </Column>
+              <Column size={9} style={style}>
+                9 columns
+              </Column>
+            </Row>
+            <Row>
+              <Column size={2} style={style}>
+                2 columns
+              </Column>
+              <Column size={7} style={style}>
+                7 columns
+              </Column>
+              <Column size={3} style={style}>
+                3 columns
+              </Column>
+            </Row>
+          </Strip>
+        </div>
+      );
+    }),
+  )
+
+  .add('Example',
+    withInfo('Example of a Strip component with Rows and Columns.')(() => (
+      <Strip
+        deep
+        image={{
+          src: 'https://assets.ubuntu.com/v1/ebdfffbf-Aubergine_suru_background.png',
+          colour: 'dark',
+        }}
+        style={{ backgroundPosition: '77% 0%' }}
+      >
+        <Row style={{ display: 'flex', alignItems: 'center', color: '#fff' }}>
+          <Column size={6}>
+            <h2>Ubuntu Enterprise Summit</h2>
+            <h3>5 &mdash; 6 December 2017</h3>
+            <h5>Find out how the world&lsquo;s top companies use Ubuntu to succeed</h5>
+            <p>
+              <Button value="Sign up now" modifier="positive" />
+            </p>
+          </Column>
+          <Column size={6}>
+            <Image src="https://assets.ubuntu.com/v1/9c1315fb-IOT_Ubuntu_devices_inforgrapic+v3.svg" alt="Ubuntu devices infographic" />
+          </Column>
+        </Row>
+      </Strip>),
+    ),
+  );

--- a/src/lib/components/Strip/Strip.test.js
+++ b/src/lib/components/Strip/Strip.test.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import Strip from './Strip';
+import Row from './Row';
+import Column from './Column';
+
+describe('Strip component', () => {
+  it('should render a simple Strip correctly', () => {
+    const strip = ReactTestRenderer.create(
+      <Strip colour="light">
+        <Row>
+          <p>This is a light Strip</p>
+        </Row>
+      </Strip>,
+    );
+    const json = strip.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a dark Strip correctly', () => {
+    const strip = ReactTestRenderer.create(
+      <Strip colour="dark">
+        <Row>
+          <p>This is a dark Strip</p>
+        </Row>
+      </Strip>,
+    );
+    const json = strip.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render an accented Strip correctly', () => {
+    const strip = ReactTestRenderer.create(
+      <Strip colour="accent">
+        <Row>
+          <p>This is an accented Strip</p>
+        </Row>
+      </Strip>,
+    );
+    const json = strip.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render an image Strip correctly', () => {
+    const strip = ReactTestRenderer.create(
+      <div style={{ maxWidth: '1030px' }}>
+        <Strip image={{
+          src: 'https://assets.ubuntu.com/v1/974c4e8c-background-origami.png?w=600',
+          colour: 'light',
+          }}
+        >
+          <Row>
+            <p>This is an image Strip that has a light image</p>
+          </Row>
+        </Strip>
+        <Strip image={{
+          src: 'https://assets.ubuntu.com/v1/ab1a7e82-background.png?w=600',
+          colour: 'dark',
+          }}
+        >
+          <Row>
+            <p>This is an image Strip that has a dark image</p>
+          </Row>
+        </Strip>
+      </div>,
+    );
+    const json = strip.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a bordered Strip correctly', () => {
+    const strip = ReactTestRenderer.create(
+      <Strip bordered>
+        <Row>
+          <p>This is a bordered Strip</p>
+        </Row>
+      </Strip>,
+    );
+    const json = strip.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a shallow Strip correctly', () => {
+    const strip = ReactTestRenderer.create(
+      <Strip padding="shallow">
+        <Row>
+          <p>This is a shallow Strip</p>
+        </Row>
+      </Strip>,
+    );
+    const json = strip.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a deep Strip correctly', () => {
+    const strip = ReactTestRenderer.create(
+      <Strip padding="deep">
+        <Row>
+          <p>This is a deep Strip</p>
+        </Row>
+      </Strip>,
+    );
+    const json = strip.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render Columns correctly', () => {
+    const strip = ReactTestRenderer.create(
+      <Strip>
+        <Row>
+          <Column size={6}>
+            6 columns
+          </Column>
+          <Column size={2}>
+            2 columns
+          </Column>
+          <Column size={4}>
+            4 columns
+          </Column>
+        </Row>
+        <Row>
+          <Column size={3}>
+            3 columns
+          </Column>
+          <Column size={9}>
+            9 columns
+          </Column>
+        </Row>
+        <Row>
+          <Column size={2}>
+            2 columns
+          </Column>
+          <Column size={7}>
+            7 columns
+          </Column>
+          <Column size={3}>
+            3 columns
+          </Column>
+        </Row>
+      </Strip>,
+    );
+    const json = strip.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/Strip/__snapshots__/Strip.test.js.snap
+++ b/src/lib/components/Strip/__snapshots__/Strip.test.js.snap
@@ -1,0 +1,213 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Strip component should render Columns correctly 1`] = `
+<section
+  className="p-strip--light"
+  style={Object {}}
+>
+  <div
+    className="row"
+    style={Object {}}
+  >
+    <div
+      className="col-6"
+      style={Object {}}
+    >
+      6 columns
+    </div>
+    <div
+      className="col-2"
+      style={Object {}}
+    >
+      2 columns
+    </div>
+    <div
+      className="col-4"
+      style={Object {}}
+    >
+      4 columns
+    </div>
+  </div>
+  <div
+    className="row"
+    style={Object {}}
+  >
+    <div
+      className="col-3"
+      style={Object {}}
+    >
+      3 columns
+    </div>
+    <div
+      className="col-9"
+      style={Object {}}
+    >
+      9 columns
+    </div>
+  </div>
+  <div
+    className="row"
+    style={Object {}}
+  >
+    <div
+      className="col-2"
+      style={Object {}}
+    >
+      2 columns
+    </div>
+    <div
+      className="col-7"
+      style={Object {}}
+    >
+      7 columns
+    </div>
+    <div
+      className="col-3"
+      style={Object {}}
+    >
+      3 columns
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Strip component should render a bordered Strip correctly 1`] = `
+<section
+  className="p-strip--light is-bordered"
+  style={Object {}}
+>
+  <div
+    className="row"
+    style={Object {}}
+  >
+    <p>
+      This is a bordered Strip
+    </p>
+  </div>
+</section>
+`;
+
+exports[`Strip component should render a dark Strip correctly 1`] = `
+<section
+  className="p-strip--dark"
+  style={Object {}}
+>
+  <div
+    className="row"
+    style={Object {}}
+  >
+    <p>
+      This is a dark Strip
+    </p>
+  </div>
+</section>
+`;
+
+exports[`Strip component should render a deep Strip correctly 1`] = `
+<section
+  className="p-strip--light is-deep"
+  style={Object {}}
+>
+  <div
+    className="row"
+    style={Object {}}
+  >
+    <p>
+      This is a deep Strip
+    </p>
+  </div>
+</section>
+`;
+
+exports[`Strip component should render a shallow Strip correctly 1`] = `
+<section
+  className="p-strip--light is-shallow"
+  style={Object {}}
+>
+  <div
+    className="row"
+    style={Object {}}
+  >
+    <p>
+      This is a shallow Strip
+    </p>
+  </div>
+</section>
+`;
+
+exports[`Strip component should render a simple Strip correctly 1`] = `
+<section
+  className="p-strip--light"
+  style={Object {}}
+>
+  <div
+    className="row"
+    style={Object {}}
+  >
+    <p>
+      This is a light Strip
+    </p>
+  </div>
+</section>
+`;
+
+exports[`Strip component should render an accented Strip correctly 1`] = `
+<section
+  className="p-strip--accent"
+  style={Object {}}
+>
+  <div
+    className="row"
+    style={Object {}}
+  >
+    <p>
+      This is an accented Strip
+    </p>
+  </div>
+</section>
+`;
+
+exports[`Strip component should render an image Strip correctly 1`] = `
+<div
+  style={
+    Object {
+      "maxWidth": "1030px",
+    }
+  }
+>
+  <section
+    className="p-strip--light p-strip--image is-light"
+    style={
+      Object {
+        "backgroundImage": "url(https://assets.ubuntu.com/v1/974c4e8c-background-origami.png?w=600)",
+      }
+    }
+  >
+    <div
+      className="row"
+      style={Object {}}
+    >
+      <p>
+        This is an image Strip that has a light image
+      </p>
+    </div>
+  </section>
+  <section
+    className="p-strip--light p-strip--image is-dark"
+    style={
+      Object {
+        "backgroundImage": "url(https://assets.ubuntu.com/v1/ab1a7e82-background.png?w=600)",
+      }
+    }
+  >
+    <div
+      className="row"
+      style={Object {}}
+    >
+      <p>
+        This is an image Strip that has a dark image
+      </p>
+    </div>
+  </section>
+</div>
+`;


### PR DESCRIPTION
# Done
- Added [Strip](https://docs.vanillaframework.io/en/patterns/strip) component
- Includes light, dark, accent, image, bordered, shallow and deep options
- Includes Row and Column subcomponents that follow the [Vanilla Grid](https://docs.vanillaframework.io/en/patterns/grid) 
- Added stories to Storybook
- Added snapshot tests

# QA
- Pull code
- Run `yarn clean` and `yarn serve` and navigate to http://localhost:6006/
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Verify the Strip component in Storybook matches the Vanilla docs

# Fixes
Fixes #59 