### PR TITLE
Add fancy output for dev

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,30 @@
+'use strict'
+const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
+const devConfig = require('../config/webpack.config.dev')
+const prodConfig = require('../config/webpack.config.prod')
+
+module.exports = (storybookBaseConfig, configType) => {
+  let appConfig = prodConfig;
+  if (configType === 'DEVELOPMENT') {
+    const appConfig = devConfig;
+  }
+  storybookBaseConfig.module.rules = [
+    ...storybookBaseConfig.module.rules,
+    ...appConfig.module.rules,
+  ];
+  storybookBaseConfig.resolve = appConfig.resolve;
+
+  if (configType === 'DEVELOPMENT') {
+    const host = process.env.HOST || 'localhost';
+    const port = process.env.PORT || 6006;
+    storybookBaseConfig.plugins.push(new FriendlyErrorsPlugin({
+      compilationSuccessInfo: {
+        messages: [`Your application is running here: http://${host}:${port}
+        `], // Intentional new line to pad output
+      },
+    }));
+    storybookBaseConfig.devServer = {quiet: true};
+  }
+
+  return storybookBaseConfig;
+};

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-react": "7.4.0",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "1.1.5",
+    "friendly-errors-webpack-plugin": "^1.6.1",
     "fs-extra": "4.0.2",
     "html-webpack-plugin": "2.30.1",
     "jest": "21.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,6 +2875,12 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.1.tgz#a3202b8fb03114aa9b40a0e3669e48b2b65a010a"
+  dependencies:
+    stackframe "^1.0.3"
+
 es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0, es-abstract@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.9.0.tgz#690829a07cae36b222e7fd9b75c0d0573eb25227"
@@ -3626,6 +3632,14 @@ forwarded@~0.1.2:
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+
+friendly-errors-webpack-plugin@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.6.1.tgz#e32781c4722f546a06a9b5d7a7cfa28520375d70"
+  dependencies:
+    chalk "^1.1.3"
+    error-stack-parser "^2.0.0"
+    string-length "^1.0.1"
 
 from@~0:
   version "0.1.7"
@@ -7965,6 +7979,10 @@ sshpk@^1.7.0:
 stable@~0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.6.tgz#910f5d2aed7b520c6e777499c1f32e139fdecb10"
+
+stackframe@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
 
 staged-git-files@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Have you ever wanted Fancy output? Well, look no further!

This change adds the Friendly Error Webpack plugin when running dev.
Seeing is believing, give it a QA!

## QA
`./run` and behold