### PR TITLE
75: Add ListTree component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ package-lock.json
 /prime/
 /stage/
 .snapcraft/
-*.snap
 _site/
 *.*.map
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export { default as HeadingIcon } from './lib/components/HeadingIcon/HeadingIcon
 export { default as Image } from './lib/components/Image/Image';
 export { default as Link } from './lib/components/Link/Link';
 export { default as List } from './lib/components/List/List';
+export { default as ListTree } from './lib/components/ListTree/ListTree';
 export { default as MediaObject } from './lib/components/MediaObject/MediaObject';
 export { default as SteppedList } from './lib/components/SteppedList/SteppedList';
 export { default as Strip } from './lib/components/Strip/Strip';

--- a/src/lib/components/Link/Link.js
+++ b/src/lib/components/Link/Link.js
@@ -3,11 +3,25 @@ import PropTypes from 'prop-types';
 import './Link.scss';
 
 const Link = (props) => {
-  let classString = '';
+  let classArray = [];
 
-  if (props.modifier) {
-    classString = props.modifier.split(/,?\s/).map(modifier => `p-link--${modifier}`).join(' ');
+  if (props.soft) {
+    classArray = [...classArray, 'p-link--soft'];
   }
+
+  if (props.strong) {
+    classArray = [...classArray, 'p-link--strong'];
+  }
+
+  if (props.inverted) {
+    classArray = [...classArray, 'p-link--inverted'];
+  }
+
+  if (props.external) {
+    classArray = [...classArray, 'p-link--external'];
+  }
+
+  const classString = classArray.join(' ');
 
   if (props.top) {
     return (
@@ -23,14 +37,20 @@ const Link = (props) => {
 };
 
 Link.defaultProps = {
-  modifier: null,
+  soft: false,
+  strong: false,
+  inverted: false,
+  external: false,
   top: false,
 };
 
 Link.propTypes = {
   children: PropTypes.node.isRequired,
   href: PropTypes.string.isRequired,
-  modifier: PropTypes.node,
+  soft: PropTypes.bool,
+  strong: PropTypes.bool,
+  inverted: PropTypes.bool,
+  external: PropTypes.bool,
   top: PropTypes.bool,
 };
 

--- a/src/lib/components/Link/Link.stories.js
+++ b/src/lib/components/Link/Link.stories.js
@@ -13,26 +13,26 @@ storiesOf('Link', module)
 
   .add('External',
     withInfo('The "external" modifier should be used on Link components that go to a different domain than the current one. ')(() => (
-      <Link modifier="external" href="https://vanillaframework.io/">External Link</Link>),
+      <Link external href="https://vanillaframework.io/">External Link</Link>),
     ),
   )
 
   .add('Soft',
     withInfo('The "soft" modifier should be used on Link components where many links are grouped together, such as a link cloud.')(() => (
-      <Link modifier="soft" href="https://vanilla-framework.github.io/vanilla-framework-react/">Soft Link</Link>),
+      <Link soft href="https://vanilla-framework.github.io/vanilla-framework-react/">Soft Link</Link>),
     ),
   )
 
   .add('Strong',
     withInfo('The "strong" modifier should be used on Link components that require emphasis or on a dark background.')(() => (
-      <Link modifier="strong" href="https://vanilla-framework.github.io/vanilla-framework-react/">Strong Link</Link>),
+      <Link strong href="https://vanilla-framework.github.io/vanilla-framework-react/">Strong Link</Link>),
     ),
   )
 
   .add('Inverted',
     withInfo('The "inverted" modifier should be used where Link components are placed on a dark background.')(() => (
       <div style={{ backgroundColor: '#333' }}>
-        <Link modifier="inverted" href="https://vanilla-framework.github.io/vanilla-framework-react/">Inverted Link</Link>
+        <Link inverted href="https://vanilla-framework.github.io/vanilla-framework-react/">Inverted Link</Link>
       </div>),
     ),
   )
@@ -44,11 +44,11 @@ storiesOf('Link', module)
   )
 
   .add('Combination',
-    withInfo('You can combine Link modifiers in the modifier prop, either space or comma-separated.')(() => (
+    withInfo('You can combine Link modifiers.')(() => (
       <div>
-        <p><Link modifier="external strong" href="https://vanillaframework.io/">External/Strong Link</Link></p>
-        <p><Link modifier="external, soft" href="https://vanillaframework.io/">External/Soft Link</Link></p>
-        <p><Link top modifier="strong" href="https://vanilla-framework.github.io/vanilla-framework-react/">Strong/Back to top Link</Link></p>
+        <p><Link external strong href="https://vanillaframework.io/">External/Strong Link</Link></p>
+        <p><Link external soft href="https://vanillaframework.io/">External/Soft Link</Link></p>
+        <p><Link top strong href="https://vanilla-framework.github.io/vanilla-framework-react/">Strong/Back to top Link</Link></p>
       </div>),
     ),
   );

--- a/src/lib/components/Link/Link.test.js
+++ b/src/lib/components/Link/Link.test.js
@@ -14,14 +14,14 @@ describe('Link component', () => {
   it('should accept modifiers correctly', () => {
     const link = ReactTestRenderer.create(
       <div>
-        <Link modifier="external" href="https://vanillaframework.io/">External Link</Link>
-        <Link modifier="soft" href="https://vanilla-framework.github.io/vanilla-framework-react/">Soft Link</Link>
-        <Link modifier="strong" href="https://vanilla-framework.github.io/vanilla-framework-react/">Strong Link</Link>
-        <Link modifier="inverted" href="https://vanilla-framework.github.io/vanilla-framework-react/">Inverted Link</Link>
+        <Link external href="https://vanillaframework.io/">External Link</Link>
+        <Link soft href="https://vanilla-framework.github.io/vanilla-framework-react/">Soft Link</Link>
+        <Link strong href="https://vanilla-framework.github.io/vanilla-framework-react/">Strong Link</Link>
+        <Link inverted href="https://vanilla-framework.github.io/vanilla-framework-react/">Inverted Link</Link>
         <Link top href="https://vanilla-framework.github.io/vanilla-framework-react/">Back to top</Link>
-        <Link modifier="external strong" href="https://vanillaframework.io/">External/Strong Link</Link>
-        <Link modifier="external, soft" href="https://vanillaframework.io/">External/Soft Link</Link>
-        <Link top modifier="strong" href="https://vanilla-framework.github.io/vanilla-framework-react/">Strong/Back to top Link</Link>
+        <Link external strong href="https://vanillaframework.io/">External/Strong Link</Link>
+        <Link external soft href="https://vanillaframework.io/">External/Soft Link</Link>
+        <Link top strong href="https://vanilla-framework.github.io/vanilla-framework-react/">Strong/Back to top Link</Link>
       </div>,
     );
     const json = link.toJSON();

--- a/src/lib/components/Link/__snapshots__/Link.test.js.snap
+++ b/src/lib/components/Link/__snapshots__/Link.test.js.snap
@@ -37,13 +37,13 @@ exports[`Link component should accept modifiers correctly 1`] = `
     </a>
   </div>
   <a
-    className="p-link--external p-link--strong"
+    className="p-link--strong p-link--external"
     href="https://vanillaframework.io/"
   >
     External/Strong Link
   </a>
   <a
-    className="p-link--external p-link--soft"
+    className="p-link--soft p-link--external"
     href="https://vanillaframework.io/"
   >
     External/Soft Link

--- a/src/lib/components/ListTree/ListTree.js
+++ b/src/lib/components/ListTree/ListTree.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './ListTree.scss';
+
+const ListTree = (props) => {
+  const listTreeChildren = React.Children.map(props.children, (child, index) =>
+    React.cloneElement(child, { index: `${index}` }),
+  );
+
+  return (
+    <ul className="p-list-tree" aria-multiselectable="true" role="tablist">
+      {listTreeChildren}
+    </ul>
+  );
+};
+
+ListTree.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+ListTree.displayName = 'ListTree';
+
+export default ListTree;

--- a/src/lib/components/ListTree/ListTree.scss
+++ b/src/lib/components/ListTree/ListTree.scss
@@ -1,0 +1,4 @@
+@import 'vanilla-framework/scss/base';
+@import 'vanilla-framework/scss/patterns_list-tree';
+@include vf-b-typography;
+@include vf-p-list-tree;

--- a/src/lib/components/ListTree/ListTree.stories.js
+++ b/src/lib/components/ListTree/ListTree.stories.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import ListTree from './ListTree';
+import ListTreeGroup from './ListTreeGroup';
+import ListTreeItem from './ListTreeItem';
+import Link from '../Link/Link';
+import Image from '../Image/Image';
+
+storiesOf('List Tree', module)
+  .add('Default',
+    withInfo('The ListTree component can be used to show a directory style listing, such as a list of files and folders within a directory.')(() => (
+      <ListTree>
+        <ListTreeGroup name="/folder">
+          <ListTreeItem>file</ListTreeItem>
+        </ListTreeGroup>
+        <ListTreeItem>
+          <Link strong href="#a">charm-helpers-sync.yaml</Link>
+        </ListTreeItem>
+        <ListTreeItem>
+          <Link strong href="#a">config.yaml</Link>
+        </ListTreeItem>
+        <ListTreeGroup name="/files">
+          <ListTreeItem>default_rsync</ListTreeItem>
+          <ListTreeItem>nagios_plugin.py</ListTreeItem>
+          <ListTreeGroup name="/plugins">
+            <ListTreeItem>check_mem.pl</ListTreeItem>
+          </ListTreeGroup>
+          <ListTreeGroup name="/misc">
+            <ListTreeGroup name="/cat">
+              <ListTreeItem>
+                <Image bordered src="http://placekitten.com/g/300/300" alt="" />
+              </ListTreeItem>
+            </ListTreeGroup>
+          </ListTreeGroup>
+        </ListTreeGroup>
+      </ListTree>),
+    ),
+  );

--- a/src/lib/components/ListTree/ListTree.test.js
+++ b/src/lib/components/ListTree/ListTree.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import ListTree from './ListTree';
+import ListTreeGroup from './ListTreeGroup';
+import ListTreeItem from './ListTreeItem';
+
+describe('ListTree component', () => {
+  it('should render a basic ListTree correctly', () => {
+    const listTree = ReactTestRenderer.create(
+      <ListTree>
+        <ListTreeGroup name="/group">
+          <ListTreeItem>file</ListTreeItem>
+        </ListTreeGroup>
+      </ListTree>);
+    const json = listTree.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a nested ListTree correctly', () => {
+    const listTree = ReactTestRenderer.create(
+      <ListTree>
+        <ListTreeGroup name="/depth1">
+          <ListTreeGroup name="/depth2">
+            <ListTreeGroup name="/depth3">
+              <ListTreeItem>file</ListTreeItem>
+            </ListTreeGroup>
+          </ListTreeGroup>
+        </ListTreeGroup>
+      </ListTree>);
+    const json = listTree.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/ListTree/ListTreeGroup.js
+++ b/src/lib/components/ListTree/ListTreeGroup.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './ListTree.scss';
+
+class ListTreeGroup extends React.Component {
+  constructor() {
+    super();
+    this.onClick = this.onClick.bind(this);
+    this.state = {
+      open: false,
+    };
+  }
+
+  onClick() {
+    const { open } = this.state;
+    this.setState({ open: !open });
+  }
+
+  render() {
+    const { index } = this.props;
+    const listTreeGroupChildren = React.Children.map(this.props.children, (child, key) =>
+      React.cloneElement(child, { index: `${index}-${key}` }),
+    );
+
+    return (
+      <li className="p-list-tree__item p-list-tree__item--group">
+        <button
+          className="p-list-tree__toggle"
+          id={`listtree-${index}-btn`}
+          role="tab"
+          aria-controls={`listtree-${index}`}
+          aria-expanded={this.state.open}
+          onClick={this.onClick}
+        >
+          {this.props.name}
+        </button>
+        <ul
+          className="p-list-tree"
+          id={`listtree-${index}`}
+          role="tabpanel"
+          aria-hidden={!(this.state.open)}
+          aria-labelledby={`listtree-${index}-btn`}
+        >
+          {listTreeGroupChildren}
+        </ul>
+      </li>
+    );
+  }
+}
+
+ListTreeGroup.defaultProps = {
+  index: '0',
+};
+
+ListTreeGroup.propTypes = {
+  children: PropTypes.node.isRequired,
+  index: PropTypes.string,
+  name: PropTypes.string.isRequired,
+};
+
+ListTreeGroup.displayName = 'ListTreeGroup';
+
+export default ListTreeGroup;

--- a/src/lib/components/ListTree/ListTreeItem.js
+++ b/src/lib/components/ListTree/ListTreeItem.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './ListTree.scss';
+
+const ListTreeItem = props => (
+  <li key={props.index} className="p-list-tree__item">
+    {props.children}
+  </li>
+);
+
+ListTreeItem.defaultProps = {
+  index: '0',
+};
+
+ListTreeItem.propTypes = {
+  children: PropTypes.node.isRequired,
+  index: PropTypes.string,
+};
+
+ListTreeItem.displayName = 'ListTreeItem';
+
+export default ListTreeItem;

--- a/src/lib/components/ListTree/__snapshots__/ListTree.test.js.snap
+++ b/src/lib/components/ListTree/__snapshots__/ListTree.test.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListTree component should render a basic ListTree correctly 1`] = `
+<ul
+  aria-multiselectable="true"
+  className="p-list-tree"
+  role="tablist"
+>
+  <li
+    className="p-list-tree__item p-list-tree__item--group"
+  >
+    <button
+      aria-controls="listtree-0"
+      aria-expanded={false}
+      className="p-list-tree__toggle"
+      id="listtree-0-btn"
+      onClick={[Function]}
+      role="tab"
+    >
+      /group
+    </button>
+    <ul
+      aria-hidden={true}
+      aria-labelledby="listtree-0-btn"
+      className="p-list-tree"
+      id="listtree-0"
+      role="tabpanel"
+    >
+      <li
+        className="p-list-tree__item"
+      >
+        file
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`ListTree component should render a nested ListTree correctly 1`] = `
+<ul
+  aria-multiselectable="true"
+  className="p-list-tree"
+  role="tablist"
+>
+  <li
+    className="p-list-tree__item p-list-tree__item--group"
+  >
+    <button
+      aria-controls="listtree-0"
+      aria-expanded={false}
+      className="p-list-tree__toggle"
+      id="listtree-0-btn"
+      onClick={[Function]}
+      role="tab"
+    >
+      /depth1
+    </button>
+    <ul
+      aria-hidden={true}
+      aria-labelledby="listtree-0-btn"
+      className="p-list-tree"
+      id="listtree-0"
+      role="tabpanel"
+    >
+      <li
+        className="p-list-tree__item p-list-tree__item--group"
+      >
+        <button
+          aria-controls="listtree-0-0"
+          aria-expanded={false}
+          className="p-list-tree__toggle"
+          id="listtree-0-0-btn"
+          onClick={[Function]}
+          role="tab"
+        >
+          /depth2
+        </button>
+        <ul
+          aria-hidden={true}
+          aria-labelledby="listtree-0-0-btn"
+          className="p-list-tree"
+          id="listtree-0-0"
+          role="tabpanel"
+        >
+          <li
+            className="p-list-tree__item p-list-tree__item--group"
+          >
+            <button
+              aria-controls="listtree-0-0-0"
+              aria-expanded={false}
+              className="p-list-tree__toggle"
+              id="listtree-0-0-0-btn"
+              onClick={[Function]}
+              role="tab"
+            >
+              /depth3
+            </button>
+            <ul
+              aria-hidden={true}
+              aria-labelledby="listtree-0-0-0-btn"
+              className="p-list-tree"
+              id="listtree-0-0-0"
+              role="tabpanel"
+            >
+              <li
+                className="p-list-tree__item"
+              >
+                file
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;


### PR DESCRIPTION
# Done
- Added [ListTree](https://docs.vanillaframework.io/en/patterns/list-tree) component
- Includes ListTreeGroup and ListTreeItem subcomponents
- Added stories to Storybook
- Added snapshot tests
- Refactored the Link component to accept individual booleans instead of a single 'modifier' prop
- Removed .snap files from .gitignore

# QA
- Pull code
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Verify the ListTree component in Storybook matches the Vanilla [docs](https://docs.vanillaframework.io/en/patterns/list-tree)

## Note
- There is a bug in Vanilla ([link](https://github.com/vanilla-framework/vanilla-framework/issues/1475)) that doesn't allow the `+` icon to change to `-` in a ListTreeGroup. If you go to `_patterns_list-tree.scss` in the node modules folder and remove the erroneous newline you can see it work properly

# Fixes
Fixes #75 