### PR TITLE
78: Add MutedHeading component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export { default as Link } from './lib/components/Link/Link';
 export { default as List } from './lib/components/List/List';
 export { default as ListTree } from './lib/components/ListTree/ListTree';
 export { default as MediaObject } from './lib/components/MediaObject/MediaObject';
+export { default as MutedHeading } from './lib/components/MutedHeading/MutedHeading';
 export { default as SteppedList } from './lib/components/SteppedList/SteppedList';
 export { default as Strip } from './lib/components/Strip/Strip';
 export { default as Switch } from './lib/components/Switch/Switch';

--- a/src/lib/components/MutedHeading/MutedHeading.js
+++ b/src/lib/components/MutedHeading/MutedHeading.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './MutedHeading.scss';
+
+const MutedHeading = props => (
+  <h4 className="p-muted-heading">
+    {props.children}
+  </h4>
+);
+
+MutedHeading.defaultProps = {
+  children: '',
+};
+
+MutedHeading.propTypes = {
+  children: PropTypes.node,
+};
+
+MutedHeading.displayName = 'MutedHeading';
+
+export default MutedHeading;

--- a/src/lib/components/MutedHeading/MutedHeading.scss
+++ b/src/lib/components/MutedHeading/MutedHeading.scss
@@ -1,0 +1,4 @@
+@import 'vanilla-framework/scss/base';
+@import 'vanilla-framework/scss/patterns_muted-heading';
+@include vf-b-typography;
+@include vf-p-muted-heading;

--- a/src/lib/components/MutedHeading/MutedHeading.stories.js
+++ b/src/lib/components/MutedHeading/MutedHeading.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import MutedHeading from './MutedHeading';
+
+storiesOf('Muted Heading', module)
+  .add('Default',
+    withInfo('The MutedHeading component can be used to introduce a collection of icons or images.')(() => (
+      <MutedHeading>Muted heading</MutedHeading>),
+    ),
+  );

--- a/src/lib/components/MutedHeading/MutedHeading.test.js
+++ b/src/lib/components/MutedHeading/MutedHeading.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import MutedHeading from './MutedHeading';
+
+describe('MutedHeading component', () => {
+  it('should render correctly', () => {
+    const mutedHeading = ReactTestRenderer.create(
+      <MutedHeading>Muted heading</MutedHeading>);
+    const json = mutedHeading.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/MutedHeading/__snapshots__/MutedHeading.test.js.snap
+++ b/src/lib/components/MutedHeading/__snapshots__/MutedHeading.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MutedHeading component should render correctly 1`] = `
+<h4
+  className="p-muted-heading"
+>
+  Muted heading
+</h4>
+`;


### PR DESCRIPTION
# Done
- Added [MutedHeading](https://docs.vanillaframework.io/en/patterns/muted-heading) component
- Added stories to Storybook
- Added snapshot tests

# QA
- Pull code
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Verify the MutedHeading component in Storybook matches the Vanilla [docs](https://docs.vanillaframework.io/en/patterns/muted-heading)

# Fixes
Fixes #78 