### PR TITLE
79: Add overlay prop for Card + refactor Card logic

### DIFF
--- a/src/lib/components/Card/Card.js
+++ b/src/lib/components/Card/Card.js
@@ -3,15 +3,38 @@ import PropTypes from 'prop-types';
 import './Card.scss';
 
 class Card extends React.Component {
+  constructor() {
+    super();
+    this.getClassString = this.getClassString.bind(this);
+    this.renderHeader = this.renderHeader.bind(this);
+  }
+
+  getClassString() {
+    let classString = 'p-card';
+
+    if (this.props.highlighted) classString = `${classString} p-card--highlighted`;
+    if (this.props.overlay) classString = `${classString} p-card--overlay`;
+
+    return classString;
+  }
+
+  renderHeader() {
+    const { header, image } = this.props;
+
+    return (
+      <header className="p-card__header">
+        {image ? <img src={image.src} alt={image.alt} /> : <h1>{header}</h1>}
+      </header>
+    );
+  }
+
   render() {
     return (
-      <div className={this.props.modifier ? `p-card--${this.props.modifier}` : 'p-card'}>
-        { this.props.image.src.length > 0 &&
-          <header className="p-card__header">
-            <img src={this.props.image.src} alt={this.props.image.alt} />
-          </header>
+      <div className={this.getClassString()}>
+        { (this.props.header || this.props.image) && this.renderHeader() }
+        { this.props.title &&
+          <h3 className="p-card__title">{this.props.title}</h3>
         }
-        <h3 className="p-card__title">{this.props.title}</h3>
         { this.props.children }
       </div>
     );
@@ -19,15 +42,23 @@ class Card extends React.Component {
 }
 
 Card.defaultProps = {
-  modifier: '',
-  image: {},
+  header: null,
+  highlighted: false,
+  image: null,
+  overlay: false,
+  title: null,
 };
 
 Card.propTypes = {
   children: PropTypes.node.isRequired,
-  image: PropTypes.object,
-  modifier: PropTypes.string,
-  title: PropTypes.string.isRequired,
+  header: PropTypes.string,
+  highlighted: PropTypes.bool,
+  image: PropTypes.shape({
+    src: PropTypes.string,
+    alt: PropTypes.string,
+  }),
+  overlay: PropTypes.bool,
+  title: PropTypes.string,
 };
 
 Card.displayName = 'Card';

--- a/src/lib/components/Card/Card.scss
+++ b/src/lib/components/Card/Card.scss
@@ -1,3 +1,4 @@
 @import 'vanilla-framework/scss/base';
 @import 'vanilla-framework/scss/patterns_card';
+@include vf-b-typography;
 @include vf-p-card;

--- a/src/lib/components/Card/Card.stories.js
+++ b/src/lib/components/Card/Card.stories.js
@@ -3,10 +3,29 @@ import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
 import Card from './Card';
+import Column from '../Strip/Column';
+import Row from '../Strip/Row';
+import Strip from '../Strip/Strip';
 
 storiesOf('Card', module)
   .add('Default',
     withInfo('The purpose of the basic card is to display information, without user interaction.')(() => (
+      <Card title="Card title">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+      </Card>),
+    ),
+  )
+
+  .add('With Header',
+    withInfo('Card components accept either a header or image prop for an optional header.')(() => (
+      <Card header="Card header" title="Card title">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+      </Card>),
+    ),
+  )
+
+  .add('With Image',
+    withInfo('Card components accept either a header or image prop for an optional header.')(() => (
       <Card
         title="Card title"
         image={{
@@ -18,10 +37,11 @@ storiesOf('Card', module)
       </Card>),
     ),
   )
+
   .add('Highlighted',
     withInfo('The highlighted card should be used when you can interact with the content.')(() => (
       <Card
-        modifier="highlighted"
+        highlighted
         title="Card title"
         image={{
           src: 'http://placekitten.com/g/64/64',
@@ -30,5 +50,31 @@ storiesOf('Card', module)
       >
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
       </Card>),
+    ),
+  )
+
+  .add('Overlay',
+    withInfo('The purpose of the overlay prop is to make the text visible in conjunction with a Strip image component.')(() => (
+      <Strip image={{
+        src: 'https://assets.ubuntu.com/v1/ab1a7e82-background.png?w=600',
+        colour: 'dark',
+        }}
+      >
+        <Row>
+          <Column size={6}><div /></Column>
+          <Column size={6}>
+            <Card
+              overlay
+              title="Card title"
+              image={{
+                src: 'http://placekitten.com/g/64/64',
+                alt: 'Placeholder',
+              }}
+            >
+              <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+            </Card>
+          </Column>
+        </Row>
+      </Strip>),
     ),
   );

--- a/src/lib/components/Card/Card.test.js
+++ b/src/lib/components/Card/Card.test.js
@@ -3,15 +3,57 @@ import ReactTestRenderer from 'react-test-renderer';
 import Card from './Card';
 
 describe('Card component', () => {
-  it('should compare with a snapshot', () => {
-    const image = {
-      src: 'http://placekitten.com/g/64/64',
-      alt: 'Placeholder',
-    };
-
+  it('should render a basic Card correctly', () => {
     const card = ReactTestRenderer.create(
-      <Card className="p-card" title="Title" image={image}>
-        Lorem ipsum dolor sit amet
+      <Card title="Card title">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+      </Card>);
+    const json = card.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render Card with an image correctly', () => {
+    const card = ReactTestRenderer.create(
+      <Card
+        title="Card title"
+        image={{
+          src: 'http://placekitten.com/g/64/64',
+          alt: 'Placeholder',
+        }}
+      >
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+      </Card>);
+    const json = card.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a highlighted Card correctly', () => {
+    const card = ReactTestRenderer.create(
+      <Card
+        highlighted
+        title="Card title"
+        image={{
+          src: 'http://placekitten.com/g/64/64',
+          alt: 'Placeholder',
+        }}
+      >
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
+      </Card>);
+    const json = card.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render an overlay Card correctly', () => {
+    const card = ReactTestRenderer.create(
+      <Card
+        overlay
+        title="Card title"
+        image={{
+          src: 'http://placekitten.com/g/64/64',
+          alt: 'Placeholder',
+        }}
+      >
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing.</p>
       </Card>);
     const json = card.toJSON();
     expect(json).toMatchSnapshot();

--- a/src/lib/components/Card/__snapshots__/Card.test.js.snap
+++ b/src/lib/components/Card/__snapshots__/Card.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Card component should compare with a snapshot 1`] = `
+exports[`Card component should render Card with an image correctly 1`] = `
 <div
   className="p-card"
 >
@@ -15,8 +15,71 @@ exports[`Card component should compare with a snapshot 1`] = `
   <h3
     className="p-card__title"
   >
-    Title
+    Card title
   </h3>
-  Lorem ipsum dolor sit amet
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipisicing.
+  </p>
+</div>
+`;
+
+exports[`Card component should render a basic Card correctly 1`] = `
+<div
+  className="p-card"
+>
+  <h3
+    className="p-card__title"
+  >
+    Card title
+  </h3>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipisicing.
+  </p>
+</div>
+`;
+
+exports[`Card component should render a highlighted Card correctly 1`] = `
+<div
+  className="p-card p-card--highlighted"
+>
+  <header
+    className="p-card__header"
+  >
+    <img
+      alt="Placeholder"
+      src="http://placekitten.com/g/64/64"
+    />
+  </header>
+  <h3
+    className="p-card__title"
+  >
+    Card title
+  </h3>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipisicing.
+  </p>
+</div>
+`;
+
+exports[`Card component should render an overlay Card correctly 1`] = `
+<div
+  className="p-card p-card--overlay"
+>
+  <header
+    className="p-card__header"
+  >
+    <img
+      alt="Placeholder"
+      src="http://placekitten.com/g/64/64"
+    />
+  </header>
+  <h3
+    className="p-card__title"
+  >
+    Card title
+  </h3>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipisicing.
+  </p>
 </div>
 `;


### PR DESCRIPTION
# Done
- Added `overlay` and `header` props to [Card](https://docs.vanillaframework.io/en/patterns/card#overlay-card) component
- Refactored prop logic so that individual bools are accepted as opposed to a single 'modifier' string, e.g.:
`<Card modifier="highlighted">` becomes `<Card highlighted>`
- Made `title` and `image` props optional
- Updated Card stories in Storybook with new prop logic
- Updated snapshot tests

# QA
- Pull code
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Verify the Card component in Storybook matches the Vanilla [docs](https://docs.vanillaframework.io/en/patterns/card)
- Check that the Card stories use the new prop logic

# Fixes
Fixes #79 