### PR TITLE
76: Add Matrix and MatrixItem components

### DIFF
--- a/src/lib/components/Matrix/Matrix.js
+++ b/src/lib/components/Matrix/Matrix.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import MatrixItem from './MatrixItem';
+
+class Matrix extends React.Component {
+  constructor() {
+    super();
+    this.generateExtras = this.generateExtras.bind(this);
+  }
+
+  generateExtras() {
+    const { children } = this.props;
+    const emptyItemCount = (2 * React.Children.count(children)) % 3;
+    const extraMatrixItems = [];
+
+    for (let i = 0; i < emptyItemCount; i += 1) {
+      extraMatrixItems.push(<MatrixItem key={i} />);
+    }
+
+    return extraMatrixItems;
+  }
+
+  render() {
+    const { children } = this.props;
+
+    // Generate extra MatrixItems to fill empty space in a row
+    const extraMatrixItems = this.generateExtras();
+
+    return (
+      <ul className="p-matrix u-clearfix">
+        { children }
+        { extraMatrixItems.length > 0 && extraMatrixItems }
+      </ul>
+    );
+  }
+}
+
+Matrix.defaultProps = {
+  children: null,
+};
+
+Matrix.propTypes = {
+  children: (props, propName, componentName) => {
+    const prop = props[propName];
+    let error = null;
+
+    React.Children.forEach(prop, (child) => {
+      if (child.type !== MatrixItem) {
+        error = new Error(`${componentName} children should be of type "MatrixItem".`);
+      }
+    });
+
+    return error;
+  },
+};
+
+Matrix.displayName = 'Matrix';
+
+export default Matrix;

--- a/src/lib/components/Matrix/Matrix.stories.js
+++ b/src/lib/components/Matrix/Matrix.stories.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import Matrix from './Matrix';
+import MatrixItem from './MatrixItem';
+
+storiesOf('Matrix', module).addDecorator(withKnobs)
+  .add('Default',
+    withInfo('The Matrix component can be useful to display a selection of items in a format that is less linear than a normal list, using an image to describe each item. MatrixItem components will display in one column on small screens. At resolutions above $breakpoint-medium, the Matrix switches to three items per row.')(() => (
+      <Matrix>
+        <MatrixItem
+          title={text('Title', 'Title')}
+          href={text('Link', '#')}
+          img={{ src: 'http://placehold.it/60x60', alt: 'icon' }}
+        >
+          {text('Text', 'Short description')}
+        </MatrixItem>
+        <MatrixItem title="Title" href="#" img={{ src: 'http://placehold.it/60x60', alt: 'icon' }}>
+          Short description
+        </MatrixItem>
+        <MatrixItem title="Title" href="#" img={{ src: 'http://placehold.it/60x60', alt: 'icon' }}>
+          Short description
+        </MatrixItem>
+        <MatrixItem title="Title" href="#" img={{ src: 'http://placehold.it/60x60', alt: 'icon' }}>
+          Short description
+        </MatrixItem>
+        <MatrixItem title="Title" href="#" img={{ src: 'http://placehold.it/60x60', alt: 'icon' }}>
+          Short description
+        </MatrixItem>
+        <MatrixItem title="Title" href="#" img={{ src: 'http://placehold.it/60x60', alt: 'icon' }}>
+          Short description
+        </MatrixItem>
+        <MatrixItem title="Title" href="#" img={{ src: 'http://placehold.it/60x60', alt: 'icon' }}>
+          Short description
+        </MatrixItem>
+        <MatrixItem title="Title" href="#" img={{ src: 'http://placehold.it/60x60', alt: 'icon' }}>
+          Short description
+        </MatrixItem>
+      </Matrix>),
+    ),
+  );

--- a/src/lib/components/Matrix/Matrix.test.js
+++ b/src/lib/components/Matrix/Matrix.test.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import Matrix from './Matrix';
+import MatrixItem from './MatrixItem';
+
+describe('Matrix component', () => {
+  it('should render a Matrix with one MatrixItem correctly', () => {
+    const matrix = ReactTestRenderer.create(
+      <Matrix>
+        <MatrixItem>
+          description
+        </MatrixItem>
+      </Matrix>,
+    );
+    const json = matrix.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a Matrix with multiple MatrixItem correctly', () => {
+    const matrix = ReactTestRenderer.create(
+      <Matrix>
+        <MatrixItem>
+          description
+        </MatrixItem>
+        <MatrixItem>
+          description
+        </MatrixItem>
+        <MatrixItem>
+          description
+        </MatrixItem>
+      </Matrix>,
+    );
+    const json = matrix.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a title when title prop provided', () => {
+    const matrix = ReactTestRenderer.create(
+      <Matrix>
+        <MatrixItem title="Title">
+          description
+        </MatrixItem>
+      </Matrix>,
+    );
+    const json = matrix.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should convert title to link when href prop provided', () => {
+    const matrix = ReactTestRenderer.create(
+      <Matrix>
+        <MatrixItem title="Title" href="#">
+          description
+        </MatrixItem>
+      </Matrix>,
+    );
+    const json = matrix.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render an image when img prop provided', () => {
+    const matrix = ReactTestRenderer.create(
+      <Matrix>
+        <MatrixItem title="Title" href="#" img={{ src: 'http://placehold.it/60x60', alt: 'icon' }}>
+          description
+        </MatrixItem>
+      </Matrix>,
+    );
+    const json = matrix.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should auto-fill to have a multiple of three MatrixItem children', () => {
+    const matrix = ReactTestRenderer.create(
+      <Matrix>
+        <MatrixItem>
+          description
+        </MatrixItem>
+        <MatrixItem>
+          description
+        </MatrixItem>
+        <MatrixItem>
+          description
+        </MatrixItem>
+        <MatrixItem>
+          description
+        </MatrixItem>
+      </Matrix>,
+    );
+    const json = matrix.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/Matrix/MatrixItem.js
+++ b/src/lib/components/Matrix/MatrixItem.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const MatrixItem = (props) => {
+  const {
+    children, href, img, title,
+  } = props;
+
+  return (
+    <li className="p-matrix__item">
+      {img && <img className="p-matrix__img" src={img.src} alt={img.alt} />}
+      <div className="p-matrix__content">
+        {title &&
+          <h3 className="p-matrix__title">
+            {href ? <a className="p-matrix__link" href={href}>{title}</a> : title}
+          </h3>}
+        <p className="p-matrix__desc">
+          { children }
+        </p>
+      </div>
+    </li>
+  );
+};
+
+MatrixItem.defaultProps = {
+  children: null,
+  href: '',
+  img: null,
+  title: '',
+};
+
+MatrixItem.propTypes = {
+  children: PropTypes.node,
+  img: PropTypes.shape({
+    src: PropTypes.string,
+    alt: PropTypes.string,
+  }),
+  href: PropTypes.string,
+  title: PropTypes.string,
+};
+
+MatrixItem.displayName = 'MatrixItem';
+
+export default MatrixItem;

--- a/src/lib/components/Matrix/__snapshots__/Matrix.test.js.snap
+++ b/src/lib/components/Matrix/__snapshots__/Matrix.test.js.snap
@@ -1,0 +1,344 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Matrix component should auto-fill to have a multiple of three MatrixItem children 1`] = `
+<ul
+  className="p-matrix u-clearfix"
+>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`Matrix component should convert title to link when href prop provided 1`] = `
+<ul
+  className="p-matrix u-clearfix"
+>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      <h3
+        className="p-matrix__title"
+      >
+        <a
+          className="p-matrix__link"
+          href="#"
+        >
+          Title
+        </a>
+      </h3>
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`Matrix component should render a Matrix with multiple MatrixItem correctly 1`] = `
+<ul
+  className="p-matrix u-clearfix"
+>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`Matrix component should render a Matrix with one MatrixItem correctly 1`] = `
+<ul
+  className="p-matrix u-clearfix"
+>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`Matrix component should render a title when title prop provided 1`] = `
+<ul
+  className="p-matrix u-clearfix"
+>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      <h3
+        className="p-matrix__title"
+      >
+        Title
+      </h3>
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`Matrix component should render an image when img prop provided 1`] = `
+<ul
+  className="p-matrix u-clearfix"
+>
+  <li
+    className="p-matrix__item"
+  >
+    <img
+      alt="icon"
+      className="p-matrix__img"
+      src="http://placehold.it/60x60"
+    />
+    <div
+      className="p-matrix__content"
+    >
+      <h3
+        className="p-matrix__title"
+      >
+        <a
+          className="p-matrix__link"
+          href="#"
+        >
+          Title
+        </a>
+      </h3>
+      <p
+        className="p-matrix__desc"
+      >
+        description
+      </p>
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+  <li
+    className="p-matrix__item"
+  >
+    <div
+      className="p-matrix__content"
+    >
+      
+      <p
+        className="p-matrix__desc"
+      />
+    </div>
+  </li>
+</ul>
+`;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -21,6 +21,8 @@ import ListItem from './components/List/ListItem';
 import ListTree from './components/ListTree/ListTree';
 import ListTreeGroup from './components/ListTree/ListTreeGroup';
 import ListTreeItem from './components/ListTree/ListTreeItem';
+import Matrix from './components/Matrix/Matrix';
+import MatrixItem from './components/Matrix/MatrixItem';
 import MediaObject from './components/MediaObject/MediaObject';
 import MutedHeading from './components/MutedHeading/MutedHeading';
 import SteppedList from './components/SteppedList/SteppedList';
@@ -36,6 +38,6 @@ import TableRow from './components/Table/TableRow';
 export {
   Accordion, AccordionItem, BlockQuote, Breadcrumb, BreadcrumbItem, Button, Card, CodeBlock,
   CodeSnippet, DividerList, DividerListItem, Footer, FooterNav, FooterNavContainer, HeadingIcon,
-  Image, InlineImages, Link, List, ListItem, ListTree, ListTreeGroup, ListTreeItem, MediaObject,
-  MutedHeading, SteppedList, SteppedListItem, Strip, StripColumn, StripRow, Switch, Table,
-  TableCell, TableRow };
+  Image, InlineImages, Link, List, ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix,
+  MatrixItem, MediaObject, MutedHeading, SteppedList, SteppedListItem, Strip, StripColumn, StripRow,
+  Switch, Table, TableCell, TableRow };


### PR DESCRIPTION
# Done
- Added [Matrix](https://docs.vanillaframework.io/en/patterns/matrix) component and MatrixItem subcomponent
- Matrix auto-fills to multiple of 3 MatrixItem children to keep styling consistent
- Added stories to Storybook
- Added snapshot tests

# QA
- Pull code
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Verify the Matrix component in Storybook matches the [Vanilla docs](https://docs.vanillaframework.io/en/patterns/matrix)

# Fixes
Fixes #76  
  