### PR TITLE
81: Add Notification component

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -25,7 +25,7 @@ serializeStories(getStorybook);
 
 // override option defaults:
 setOptions({
-  name: 'Vanilla React',
+  name: 'Vanilla Framework React',
   url: 'https://github.com/vanilla-framework/vanilla-framework-react',
   downPanelInRight: true,
 });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@storybook/addon-info": "^3.2.14",
     "@storybook/addon-knobs": "^3.2.17",
     "@storybook/react": "^3.2.14",
+    "classnames": "^2.2.5",
     "dedent-js": "^1.0.1",
     "natural-compare-lite": "^1.4.0",
     "pretty": "^2.0.0",

--- a/src/lib/components/Notification/Notification.js
+++ b/src/lib/components/Notification/Notification.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+const Notification = (props) => {
+  const {
+    action, children, status, caution, information, negative, positive,
+  } = props;
+
+  const className = classNames({
+    'p-notification--information': information,
+    'p-notification--positive': positive,
+    'p-notification--caution': caution,
+    'p-notification--negative': negative,
+  });
+
+  return (
+    <div className={className || 'p-notification'}>
+      <p className="p-notification__response">
+        {status && <span className="p-notification__status">{status}</span>}
+        {children}
+        {action && <a href={action.href} className="p-notification__action">{action.value}</a>}
+      </p>
+    </div>
+  );
+};
+
+Notification.defaultProps = {
+  action: null,
+  caution: false,
+  information: false,
+  negative: false,
+  positive: false,
+  status: null,
+};
+
+Notification.propTypes = {
+  action: PropTypes.shape({
+    value: PropTypes.string,
+    href: PropTypes.string,
+  }),
+  caution: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  information: PropTypes.bool,
+  negative: PropTypes.bool,
+  positive: PropTypes.bool,
+  status: PropTypes.string,
+};
+
+Notification.displayName = 'Notification';
+
+export default Notification;

--- a/src/lib/components/Notification/Notification.stories.js
+++ b/src/lib/components/Notification/Notification.stories.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import Notification from './Notification';
+
+storiesOf('Notification', module).addDecorator(withKnobs)
+  .add('Default',
+    withInfo('Notification components are used to display global information. A Notification will display at the top and fill the full width of the page. It can be default, info, caution, negative or position.')(() => (
+      <Notification
+        information={boolean('Information', false)}
+        positive={boolean('Positive', false)}
+        caution={boolean('Caution', false)}
+        negative={boolean('Negative', false)}
+        status={text('Status', null)}
+        action={{
+          value: text('Action text', null),
+          href: text('Action href', null),
+        }}
+      >
+        {text('Text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!')}
+      </Notification>),
+    ),
+  )
+
+  .add('Information',
+    withInfo('The information prop should be used to convey an information message.')(() => (
+      <Notification
+        information={boolean('Information', true)}
+        positive={boolean('Positive', false)}
+        caution={boolean('Caution', false)}
+        negative={boolean('Negative', false)}
+        status={text('Status', 'Information:')}
+        action={{
+          value: text('Action text', null),
+          href: text('Action href', null),
+        }}
+      >
+        {text('Text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!')}
+      </Notification>),
+    ),
+  )
+
+  .add('Positive',
+    withInfo('This positive variant should be used to convey success or completion.')(() => (
+      <Notification
+        information={boolean('Information', false)}
+        positive={boolean('Positive', true)}
+        caution={boolean('Caution', false)}
+        negative={boolean('Negative', false)}
+        status={text('Status', 'Success:')}
+        action={{
+          value: text('Action text', null),
+          href: text('Action href', null),
+        }}
+      >
+        {text('Text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!')}
+      </Notification>),
+    ),
+  )
+
+  .add('Caution',
+    withInfo('This caution variant should be used to convey information that is not critical but the user should be aware of.')(() => (
+      <Notification
+        information={boolean('Information', false)}
+        positive={boolean('Positive', false)}
+        caution={boolean('Caution', true)}
+        negative={boolean('Negative', false)}
+        status={text('Status', 'Blocked:')}
+        action={{
+          value: text('Action text', null),
+          href: text('Action href', null),
+        }}
+      >
+        {text('Text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!')}
+      </Notification>),
+    ),
+  )
+
+  .add('Negative',
+    withInfo('This negative variant should be used to convey information that is critical and the user should take action.')(() => (
+      <Notification
+        information={boolean('Information', false)}
+        positive={boolean('Positive', false)}
+        caution={boolean('Caution', false)}
+        negative={boolean('Negative', true)}
+        status={text('Status', 'Error:')}
+        action={{
+          value: text('Action text', null),
+          href: text('Action href', null),
+        }}
+      >
+        {text('Text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!')}
+      </Notification>),
+    ),
+  )
+
+  .add('With Action',
+    withInfo('Notification components have the ability to add an action link to them.')(() => (
+      <Notification
+        information={boolean('Information', false)}
+        positive={boolean('Positive', false)}
+        caution={boolean('Caution', false)}
+        negative={boolean('Negative', false)}
+        status={text('Status', null)}
+        action={{
+          value: text('Action text', 'Dismiss'),
+          href: text('Action href', '#'),
+        }}
+      >
+        {text('Text', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nesciunt ipsum nemo autem reiciendis nulla tempore natus repudiandae dolorem. Corporis maxime, iure maiores repellat, odit facilis!')}
+      </Notification>),
+    ),
+  );

--- a/src/lib/components/Notification/Notification.test.js
+++ b/src/lib/components/Notification/Notification.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import Notification from './Notification';
+
+describe('Notification component', () => {
+  it('should render a default Notification', () => {
+    const notification = ReactTestRenderer.create(
+      <Notification>
+        This is a default Notification
+      </Notification>);
+    const json = notification.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a status if prop is provided', () => {
+    const notification = ReactTestRenderer.create(
+      <Notification status="Status:">
+        This is a Notification with a status
+      </Notification>);
+    const json = notification.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render an action if prop is provided', () => {
+    const notification = ReactTestRenderer.create(
+      <Notification action={{ value: 'Action', href: '#' }}>
+        This is a Notification with an action
+      </Notification>);
+    const json = notification.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render an information Notification', () => {
+    const notification = ReactTestRenderer.create(
+      <Notification information>
+        This is an information Notification
+      </Notification>);
+    const json = notification.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a positive Notification', () => {
+    const notification = ReactTestRenderer.create(
+      <Notification positive>
+        This is a positive Notification
+      </Notification>);
+    const json = notification.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a caution Notification', () => {
+    const notification = ReactTestRenderer.create(
+      <Notification caution>
+        This is a caution Notification
+      </Notification>);
+    const json = notification.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a negative Notification', () => {
+    const notification = ReactTestRenderer.create(
+      <Notification negative>
+        This is a negative Notification
+      </Notification>);
+    const json = notification.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});
+

--- a/src/lib/components/Notification/__snapshots__/Notification.test.js.snap
+++ b/src/lib/components/Notification/__snapshots__/Notification.test.js.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Notification component should render a caution Notification 1`] = `
+<div
+  className="p-notification--caution"
+>
+  <p
+    className="p-notification__response"
+  >
+    This is a caution Notification
+  </p>
+</div>
+`;
+
+exports[`Notification component should render a default Notification 1`] = `
+<div
+  className="p-notification"
+>
+  <p
+    className="p-notification__response"
+  >
+    This is a default Notification
+  </p>
+</div>
+`;
+
+exports[`Notification component should render a negative Notification 1`] = `
+<div
+  className="p-notification--negative"
+>
+  <p
+    className="p-notification__response"
+  >
+    This is a negative Notification
+  </p>
+</div>
+`;
+
+exports[`Notification component should render a positive Notification 1`] = `
+<div
+  className="p-notification--positive"
+>
+  <p
+    className="p-notification__response"
+  >
+    This is a positive Notification
+  </p>
+</div>
+`;
+
+exports[`Notification component should render a status if prop is provided 1`] = `
+<div
+  className="p-notification"
+>
+  <p
+    className="p-notification__response"
+  >
+    <span
+      className="p-notification__status"
+    >
+      Status:
+    </span>
+    This is a Notification with a status
+  </p>
+</div>
+`;
+
+exports[`Notification component should render an action if prop is provided 1`] = `
+<div
+  className="p-notification"
+>
+  <p
+    className="p-notification__response"
+  >
+    This is a Notification with an action
+    <a
+      className="p-notification__action"
+      href="#"
+    >
+      Action
+    </a>
+  </p>
+</div>
+`;
+
+exports[`Notification component should render an information Notification 1`] = `
+<div
+  className="p-notification--information"
+>
+  <p
+    className="p-notification__response"
+  >
+    This is an information Notification
+  </p>
+</div>
+`;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -26,6 +26,7 @@ import MatrixItem from './components/Matrix/MatrixItem';
 import MediaObject from './components/MediaObject/MediaObject';
 import Modal from './components/Modal/Modal';
 import MutedHeading from './components/MutedHeading/MutedHeading';
+import Notification from './components/Notification/Notification';
 import SteppedList from './components/SteppedList/SteppedList';
 import SteppedListItem from './components/SteppedList/SteppedListItem';
 import Strip from './components/Strip/Strip';
@@ -42,5 +43,5 @@ export {
   Accordion, AccordionItem, BlockQuote, Breadcrumb, BreadcrumbItem, Button, Card, CodeBlock,
   CodeSnippet, DividerList, DividerListItem, Footer, FooterNav, FooterNavContainer, HeadingIcon,
   Image, InlineImages, Link, List, ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix,
-  MatrixItem, MediaObject, Modal, MutedHeading, SteppedList, SteppedListItem, Strip, StripColumn,
-  StripRow, Switch, Table, TableCell, TableRow, Tabs, TabsItem };
+  MatrixItem, MediaObject, Modal, MutedHeading, Notification, SteppedList, SteppedListItem, Strip,
+  StripColumn, StripRow, Switch, Table, TableCell, TableRow, Tabs, TabsItem };


### PR DESCRIPTION
# Done
- Added [Notification](https://docs.vanillaframework.io/en/patterns/notification)
- Includes Default, Information, Positive, Caution and Negative types
- Added `classnames` to dependencies
- Added stories/knobs to Storybook
- Added snapshot tests
- Updated Storybook name in upper-left corner to 'Vanilla Framework React' to be a bit clearer

# QA
- Pull code
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Verify the Notification component in Storybook matches the [Vanilla docs](https://docs.vanillaframework.io/en/patterns/notification)

# Fixes
Fixes #81 
  