### PR TITLE
99: Add Modal component

### DIFF
--- a/src/lib/components/Image/Image.js
+++ b/src/lib/components/Image/Image.js
@@ -13,13 +13,14 @@ const Image = (props) => {
 
   const classString = classArray.join(' ');
 
-  return <img className={classString} src={props.src} alt={props.alt} />;
+  return <img style={props.style} className={classString} src={props.src} alt={props.alt} />;
 };
 
 Image.defaultProps = {
   alt: '',
   bordered: false,
   shadowed: false,
+  style: null,
 };
 
 Image.propTypes = {
@@ -27,6 +28,7 @@ Image.propTypes = {
   alt: PropTypes.string,
   bordered: PropTypes.bool,
   shadowed: PropTypes.bool,
+  style: PropTypes.object,
 };
 
 Image.displayName = 'Image';

--- a/src/lib/components/Image/Image.js
+++ b/src/lib/components/Image/Image.js
@@ -13,7 +13,14 @@ const Image = (props) => {
 
   const classString = classArray.join(' ');
 
-  return <img style={props.style} className={classString} src={props.src} alt={props.alt} />;
+  return (
+    <img
+      style={props.style}
+      className={classString}
+      src={props.src}
+      alt={props.alt}
+    />
+  );
 };
 
 Image.defaultProps = {

--- a/src/lib/components/Image/__snapshots__/Image.test.js.snap
+++ b/src/lib/components/Image/__snapshots__/Image.test.js.snap
@@ -5,6 +5,7 @@ exports[`Image component should render a default Image correctly 1`] = `
   alt=""
   className=""
   src="http://placekitten.com/g/300/300"
+  style={null}
 />
 `;
 
@@ -13,6 +14,7 @@ exports[`Image component should render bordered prop correctly 1`] = `
   alt=""
   className="p-image--bordered"
   src="http://placekitten.com/g/300/300"
+  style={null}
 />
 `;
 
@@ -21,6 +23,7 @@ exports[`Image component should render both bordered and shadowed props correctl
   alt=""
   className="p-image--bordered p-image--shadowed"
   src="http://placekitten.com/g/300/300"
+  style={null}
 />
 `;
 
@@ -29,5 +32,6 @@ exports[`Image component should render shadowed prop correctly 1`] = `
   alt=""
   className="p-image--shadowed"
   src="http://placekitten.com/g/300/300"
+  style={null}
 />
 `;

--- a/src/lib/components/InlineImages/__snapshots__/InlineImages.test.js.snap
+++ b/src/lib/components/InlineImages/__snapshots__/InlineImages.test.js.snap
@@ -11,6 +11,7 @@ exports[`InlineImages component should render the InlineImages component correct
       alt=""
       className="p-image--bordered"
       src="http://placekitten.com/g/200/200"
+      style={null}
     />
   </li>
   <li
@@ -20,6 +21,7 @@ exports[`InlineImages component should render the InlineImages component correct
       alt=""
       className="p-image--bordered"
       src="http://placekitten.com/g/400/400"
+      style={null}
     />
   </li>
   <li
@@ -29,6 +31,7 @@ exports[`InlineImages component should render the InlineImages component correct
       alt=""
       className="p-image--bordered"
       src="http://placekitten.com/g/300/300"
+      style={null}
     />
   </li>
   <li
@@ -38,6 +41,7 @@ exports[`InlineImages component should render the InlineImages component correct
       alt=""
       className="p-image--bordered"
       src="http://placekitten.com/g/500/500"
+      style={null}
     />
   </li>
   <li
@@ -47,6 +51,7 @@ exports[`InlineImages component should render the InlineImages component correct
       alt=""
       className="p-image--bordered"
       src="http://placekitten.com/g/800/800"
+      style={null}
     />
   </li>
   <li
@@ -56,6 +61,7 @@ exports[`InlineImages component should render the InlineImages component correct
       alt=""
       className="p-image--bordered"
       src="http://placekitten.com/g/700/700"
+      style={null}
     />
   </li>
 </ul>

--- a/src/lib/components/Modal/Modal.js
+++ b/src/lib/components/Modal/Modal.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Modal = (props) => {
+  const {
+    children, onClick, show, title,
+  } = props;
+
+  return (
+    <div
+      className="p-modal"
+      style={{ display: show ? 'flex' : 'none' }}
+    >
+      <div
+        className="p-modal__dialog"
+        role="dialog"
+        aria-labelledby="modal-title"
+        aria-describedby="modal-description"
+      >
+        <header className="p-modal__header">
+          <h2 className="p-modal__title">{ title }</h2>
+          <button
+            className="p-modal__close"
+            aria-label="Close active modal"
+            onClick={onClick}
+          >
+            Close
+          </button>
+        </header>
+        { children }
+      </div>
+    </div>
+  );
+};
+
+Modal.defaultProps = {
+  onClick: () => 1,
+  show: false,
+  title: null,
+};
+
+Modal.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
+  show: PropTypes.bool,
+  title: PropTypes.string,
+};
+
+Modal.displayName = 'Modal';
+
+export default Modal;

--- a/src/lib/components/Modal/Modal.stories.js
+++ b/src/lib/components/Modal/Modal.stories.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import Modal from './Modal';
+import Button from '../Button/Button';
+import Image from '../Image/Image';
+
+class ModalExample extends React.Component {
+  constructor() {
+    super();
+    this.state = { modal: false };
+    this.toggleModal = this.toggleModal.bind(this);
+  }
+
+  toggleModal() {
+    this.setState({ modal: !this.state.modal });
+  }
+
+  render() {
+    return (
+      <div>
+        <Button neutral value="Show modal" onClick={this.toggleModal} />
+        <Modal show={this.state.modal} title={text('Title', 'Cat Modal')} onClick={this.toggleModal}>
+          <p>{text('Text', 'This is a Modal with a picture of a cat. Check it out!')}</p>
+          <Image
+            style={{ display: 'block', margin: '1rem auto' }}
+            bordered
+            src="http://placekitten.com/g/300/300"
+            alt="cat"
+          />
+        </Modal>
+      </div>
+    );
+  }
+}
+
+storiesOf('Modal', module).addDecorator(withKnobs)
+  .add('Default',
+    withInfo('The Modal component can be useful to overlay an area of the screen which can contain a prompt, dialog or interaction. Note that opening and closing the Modal requires props from a parent component, for example by adjusting it in the Knobs panel in Storybook.')(() => (
+      <div>
+        <Modal show={boolean('Show', false)} title={text('Title', 'Modal title')}>
+          <p>{text('Description', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dolores sed, distinctio, alias accusantium veritatis magni magnam sapiente amet possimus in quis nisi autem iste, ullam facilis, deleniti voluptas enim. Perspiciatis vero eius debitis deserunt beatae doloribus tenetur accusantium consectetur nesciunt, minus, magni pariatur. Autem ipsa excepturi quod ducimus debitis voluptas!')}</p>
+        </Modal>
+      </div>),
+    ),
+  )
+
+  .add('Example',
+    withInfo('This is an example of how a Modal might be used in an application, in which the parent component (ModalExample) controls the \'show\' prop.')(() => (
+      <ModalExample />),
+    ),
+  );

--- a/src/lib/components/Modal/Modal.test.js
+++ b/src/lib/components/Modal/Modal.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import Modal from './Modal';
+
+describe('Modal component', () => {
+  it('should be hidden if show prop is false', () => {
+    const modal = ReactTestRenderer.create(
+      <Modal>
+        <p>Modal text</p>
+      </Modal>);
+    const json = modal.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should show if show prop is true', () => {
+    const modal = ReactTestRenderer.create(
+      <Modal show>
+        <p>Modal text</p>
+      </Modal>);
+    const json = modal.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should display a title if prop is provided', () => {
+    const modal = ReactTestRenderer.create(
+      <Modal show title="Modal title">
+        <p>Modal text</p>
+      </Modal>);
+    const json = modal.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/Modal/__snapshots__/Modal.test.js.snap
+++ b/src/lib/components/Modal/__snapshots__/Modal.test.js.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal component should be hidden if show prop is false 1`] = `
+<div
+  className="p-modal"
+  style={
+    Object {
+      "display": "none",
+    }
+  }
+>
+  <div
+    aria-describedby="modal-description"
+    aria-labelledby="modal-title"
+    className="p-modal__dialog"
+    role="dialog"
+  >
+    <header
+      className="p-modal__header"
+    >
+      <h2
+        className="p-modal__title"
+      />
+      <button
+        aria-label="Close active modal"
+        className="p-modal__close"
+        onClick={[Function]}
+      >
+        Close
+      </button>
+    </header>
+    <p>
+      Modal text
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Modal component should display a title if prop is provided 1`] = `
+<div
+  className="p-modal"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
+>
+  <div
+    aria-describedby="modal-description"
+    aria-labelledby="modal-title"
+    className="p-modal__dialog"
+    role="dialog"
+  >
+    <header
+      className="p-modal__header"
+    >
+      <h2
+        className="p-modal__title"
+      >
+        Modal title
+      </h2>
+      <button
+        aria-label="Close active modal"
+        className="p-modal__close"
+        onClick={[Function]}
+      >
+        Close
+      </button>
+    </header>
+    <p>
+      Modal text
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Modal component should show if show prop is true 1`] = `
+<div
+  className="p-modal"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
+>
+  <div
+    aria-describedby="modal-description"
+    aria-labelledby="modal-title"
+    className="p-modal__dialog"
+    role="dialog"
+  >
+    <header
+      className="p-modal__header"
+    >
+      <h2
+        className="p-modal__title"
+      />
+      <button
+        aria-label="Close active modal"
+        className="p-modal__close"
+        onClick={[Function]}
+      >
+        Close
+      </button>
+    </header>
+    <p>
+      Modal text
+    </p>
+  </div>
+</div>
+`;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -24,6 +24,7 @@ import ListTreeItem from './components/ListTree/ListTreeItem';
 import Matrix from './components/Matrix/Matrix';
 import MatrixItem from './components/Matrix/MatrixItem';
 import MediaObject from './components/MediaObject/MediaObject';
+import Modal from './components/Modal/Modal';
 import MutedHeading from './components/MutedHeading/MutedHeading';
 import SteppedList from './components/SteppedList/SteppedList';
 import SteppedListItem from './components/SteppedList/SteppedListItem';
@@ -39,5 +40,5 @@ export {
   Accordion, AccordionItem, BlockQuote, Breadcrumb, BreadcrumbItem, Button, Card, CodeBlock,
   CodeSnippet, DividerList, DividerListItem, Footer, FooterNav, FooterNavContainer, HeadingIcon,
   Image, InlineImages, Link, List, ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix,
-  MatrixItem, MediaObject, MutedHeading, SteppedList, SteppedListItem, Strip, StripColumn, StripRow,
-  Switch, Table, TableCell, TableRow };
+  MatrixItem, MediaObject, Modal, MutedHeading, SteppedList, SteppedListItem, Strip, StripColumn,
+  StripRow, Switch, Table, TableCell, TableRow };


### PR DESCRIPTION
# Done
- Added [Modal](https://docs.vanillaframework.io/en/patterns/modal) component
- Added stories/knobs to Storybook
- Added snapshot tests
- Made a small change to the `Image` component to allow a custom `style` prop

# QA
- Pull code
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Verify the Modal component in Storybook matches the [Vanilla docs](https://docs.vanillaframework.io/en/patterns/modal)

# Fixes
Fixes #99 