### PR TITLE
112: Update Button tests

### DIFF
--- a/src/lib/components/Button/Button.js
+++ b/src/lib/components/Button/Button.js
@@ -1,63 +1,80 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 class Button extends React.Component {
   constructor() {
     super();
     this.onClick = this.onClick.bind(this);
-    this.getClassString = this.getClassString.bind(this);
   }
 
   onClick(event) {
-    if (!this.props.disabled) {
-      this.props.onClick(event);
+    const { disabled, onClick } = this.props;
+
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+
+    if (onClick) {
+      onClick(event);
     }
   }
 
-  getClassString() {
-    let classString = 'p-button--base';
-
-    if (this.props.positive) classString = 'p-button--positive';
-    else if (this.props.negative) classString = 'p-button--negative';
-    else if (this.props.brand) classString = 'p-button--brand';
-    else if (this.props.neutral) classString = 'p-button--neutral';
-    if (this.props.inline) classString = `${classString} is-inline`;
-
-    return classString;
-  }
-
   render() {
+    const {
+      children, value, disabled, neutral, brand, negative, positive, inline, href,
+    } = this.props;
+
+    const Tag = href ? 'a' : 'button';
+
+    const className = classNames({
+      'p-button--base': !(positive || negative || neutral || brand),
+      'p-button--positive': positive,
+      'p-button--negative': negative,
+      'p-button--neutral': neutral,
+      'p-button--brand': brand,
+      'is-inline': inline,
+      'is--disabled': (Tag === 'a' && disabled),
+    });
+
     return (
-      <button
-        className={this.getClassString()}
-        onClick={this.props.onClick}
-        disabled={this.props.disabled}
+      <Tag
+        className={className}
+        href={Tag === 'a' ? href : undefined}
+        onClick={this.onClick}
+        disabled={disabled}
       >
-        {this.props.value}
-      </button>
+        { value || children }
+      </Tag>
     );
   }
 }
 
 Button.defaultProps = {
-  neutral: false,
   brand: false,
-  negative: false,
-  positive: false,
+  children: null,
   disabled: false,
+  href: null,
   inline: false,
+  negative: false,
+  neutral: false,
   onClick: () => null,
+  positive: false,
+  value: null,
 };
 
 Button.propTypes = {
-  value: PropTypes.string.isRequired,
-  neutral: PropTypes.bool,
   brand: PropTypes.bool,
-  negative: PropTypes.bool,
-  positive: PropTypes.bool,
-  inline: PropTypes.bool,
+  children: PropTypes.node,
   disabled: PropTypes.bool,
+  href: PropTypes.string,
+  inline: PropTypes.bool,
+  negative: PropTypes.bool,
+  neutral: PropTypes.bool,
   onClick: PropTypes.func,
+  positive: PropTypes.bool,
+  value: PropTypes.string,
 };
 
 Button.displayName = 'Button';

--- a/src/lib/components/Button/Button.js
+++ b/src/lib/components/Button/Button.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import getClassName from '../../utils/getClassName';
 
 class Button extends React.Component {
   constructor() {
@@ -23,19 +23,20 @@ class Button extends React.Component {
 
   render() {
     const {
-      children, value, disabled, neutral, brand, negative, positive, inline, href,
+      children, value, disabled, href, positive, negative, brand, neutral, inline,
     } = this.props;
-
     const Tag = href ? 'a' : 'button';
 
-    const className = classNames({
-      'p-button--base': !(positive || negative || neutral || brand),
+    const customClasses = this.props.className;
+    const className = getClassName({
+      'p-button--base': !(positive || negative || brand || neutral),
+      'p-button--neutral': neutral,
       'p-button--positive': positive,
       'p-button--negative': negative,
-      'p-button--neutral': neutral,
       'p-button--brand': brand,
       'is-inline': inline,
-      'is--disabled': (Tag === 'a' && disabled),
+      'is--disabled': disabled,
+      [`${customClasses}`]: customClasses,
     });
 
     return (
@@ -54,6 +55,7 @@ class Button extends React.Component {
 Button.defaultProps = {
   brand: false,
   children: null,
+  className: null,
   disabled: false,
   href: null,
   inline: false,
@@ -67,6 +69,7 @@ Button.defaultProps = {
 Button.propTypes = {
   brand: PropTypes.bool,
   children: PropTypes.node,
+  className: PropTypes.string,
   disabled: PropTypes.bool,
   href: PropTypes.string,
   inline: PropTypes.bool,

--- a/src/lib/components/Button/Button.stories.js
+++ b/src/lib/components/Button/Button.stories.js
@@ -7,7 +7,7 @@ import Button from './Button';
 
 storiesOf('Buttons', module).addDecorator(withKnobs)
   .add('Base',
-    withInfo('A base button is usually used alongside a neutral button. Precedence for button type is: base < neutral < brand < negative < positive.')(() => (
+    withInfo('Buttons will accept children or a value prop for the inner text. A base button is usually used alongside a neutral button.')(() => (
       <Button
         neutral={boolean('Neutral', false)}
         brand={boolean('Brand', false)}
@@ -15,8 +15,25 @@ storiesOf('Buttons', module).addDecorator(withKnobs)
         positive={boolean('Positive', false)}
         inline={boolean('Inline', false)}
         disabled={boolean('Disabled', false)}
-        value={text('Value', 'Base button 😶')}
-      />),
+        href={text('href', null)}
+      >
+        {text('Value', 'Base button 😶')}
+      </Button>),
+    ),
+  )
+  .add('Link',
+    withInfo('If an href prop is provided, the Button will be rendered as an anchor tag with button styling.')(() => (
+      <Button
+        neutral={boolean('Neutral', false)}
+        brand={boolean('Brand', false)}
+        negative={boolean('Negative', false)}
+        positive={boolean('Positive', false)}
+        inline={boolean('Inline', false)}
+        disabled={boolean('Disabled', false)}
+        href={text('href', 'https://vanilla-framework.github.io/vanilla-framework-react/')}
+      >
+        {text('Value', 'Link button')}
+      </Button>),
     ),
   )
   .add('Neutral',
@@ -28,6 +45,7 @@ storiesOf('Buttons', module).addDecorator(withKnobs)
         positive={boolean('Positive', false)}
         inline={boolean('Inline', false)}
         disabled={boolean('Disabled', false)}
+        href={text('href', null)}
         value={text('Value', 'Neutral button 😐')}
       />),
     ),
@@ -41,6 +59,7 @@ storiesOf('Buttons', module).addDecorator(withKnobs)
         positive={boolean('Positive', false)}
         inline={boolean('Inline', false)}
         disabled={boolean('Disabled', false)}
+        href={text('href', null)}
         value={text('Value', 'Brand button 💥')}
       />),
     ),
@@ -54,6 +73,7 @@ storiesOf('Buttons', module).addDecorator(withKnobs)
         positive={boolean('Positive', false)}
         inline={boolean('Inline', false)}
         disabled={boolean('Disabled', false)}
+        href={text('href', null)}
         value={text('Value', 'Negative button 😡')}
       />),
     ),
@@ -67,6 +87,7 @@ storiesOf('Buttons', module).addDecorator(withKnobs)
         positive={boolean('Positive', true)}
         inline={boolean('Inline', false)}
         disabled={boolean('Disabled', false)}
+        href={text('href', null)}
         value={text('Value', 'Positive button 😁')}
       />),
     ),
@@ -81,6 +102,7 @@ storiesOf('Buttons', module).addDecorator(withKnobs)
           positive={boolean('Positive', false)}
           inline={boolean('Inline', true)}
           disabled={boolean('Disabled', false)}
+          href={text('href', null)}
           value={text('Value', 'Inline button')}
         />
       </p>),
@@ -95,7 +117,24 @@ storiesOf('Buttons', module).addDecorator(withKnobs)
         positive={boolean('Positive', false)}
         inline={boolean('Inline', false)}
         disabled={boolean('Disabled', true)}
+        href={text('href', null)}
         value={text('Value', 'Disabled button')}
       />),
+    ),
+  )
+  .add('Function',
+    withInfo('Custom functions are passed to the Button component via the onClick prop')(() => (
+      <Button
+        neutral={boolean('Neutral', false)}
+        brand={boolean('Brand', false)}
+        negative={boolean('Negative', false)}
+        positive={boolean('Positive', true)}
+        inline={boolean('Inline', false)}
+        disabled={boolean('Disabled', false)}
+        href={text('href', null)}
+        onClick={() => alert('You clicked a button!')} // eslint-disable-line no-alert
+      >
+        {text('Value', 'Click me!')}
+      </Button>),
     ),
   );

--- a/src/lib/components/Button/Button.test.js
+++ b/src/lib/components/Button/Button.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
+import { mount, shallow } from 'enzyme';
 import Button from './Button';
 
-describe('Button component', () => {
+describe('<Button>', () => {
   it('should render a simple Button correctly', () => {
     const button = ReactTestRenderer.create(
       <Button value="Submit" />);
@@ -22,6 +23,44 @@ describe('Button component', () => {
       </div>);
     const json = button.toJSON();
     expect(json).toMatchSnapshot();
+  });
+
+  it('should render a button element by default', () => {
+    const button = shallow(<Button>Button</Button>);
+    expect(button.find('button').hostNodes().length).toBe(1);
+    expect(button.find('a').hostNodes().length).toBe(0);
+  });
+
+  it('should render an anchor element if href exists', () => {
+    const button = shallow(<Button href="/link">Link</Button>);
+    expect(button.find('a').hostNodes().length).toBe(1);
+    expect(button.find('button').hostNodes().length).toBe(0);
+  });
+
+  it('should be the same whether children or value prop is passed through', () => {
+    const text = 'Value';
+    const buttonChild = shallow(<Button>{text}</Button>);
+    const buttonValue = shallow(<Button value={text} />);
+    expect(buttonChild.html()).toBe(buttonValue.html());
+
+    const newButtonValue = shallow(<Button value="New Value" />);
+    expect(buttonChild.html()).not.toBe(newButtonValue.html());
+  });
+
+  it('calls onClick if it exists', () => {
+    const onClick = jest.fn();
+    const button = mount(<Button onClick={onClick}>onClick test</Button>);
+
+    button.find('button').hostNodes().simulate('click');
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('does not call onClick if it exists and is disabled', () => {
+    const onClick = jest.fn();
+    const button = mount(<Button disabled onClick={onClick}>onClick test</Button>);
+
+    button.find('button').hostNodes().simulate('click');
+    expect(onClick).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/lib/components/Button/__snapshots__/Button.test.js.snap
@@ -1,10 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Button component should render a modified Button correctly 1`] = `
+exports[`<Button> should render a modified Button correctly 1`] = `
 <div>
   <button
     className="p-button--neutral"
     disabled={false}
+    href={undefined}
     onClick={[Function]}
   >
     Neutral
@@ -12,6 +13,7 @@ exports[`Button component should render a modified Button correctly 1`] = `
   <button
     className="p-button--negative"
     disabled={false}
+    href={undefined}
     onClick={[Function]}
   >
     Negative
@@ -19,6 +21,7 @@ exports[`Button component should render a modified Button correctly 1`] = `
   <button
     className="p-button--positive"
     disabled={false}
+    href={undefined}
     onClick={[Function]}
   >
     Positive
@@ -26,6 +29,7 @@ exports[`Button component should render a modified Button correctly 1`] = `
   <button
     className="p-button--brand"
     disabled={false}
+    href={undefined}
     onClick={[Function]}
   >
     Brand
@@ -33,13 +37,15 @@ exports[`Button component should render a modified Button correctly 1`] = `
   <button
     className="p-button--base is-inline"
     disabled={false}
+    href={undefined}
     onClick={[Function]}
   >
     Inline
   </button>
   <button
-    className="p-button--base"
+    className="p-button--base is--disabled"
     disabled={true}
+    href={undefined}
     onClick={[Function]}
   >
     Disabled
@@ -47,10 +53,11 @@ exports[`Button component should render a modified Button correctly 1`] = `
 </div>
 `;
 
-exports[`Button component should render a simple Button correctly 1`] = `
+exports[`<Button> should render a simple Button correctly 1`] = `
 <button
   className="p-button--base"
   disabled={false}
+  href={undefined}
   onClick={[Function]}
 >
   Submit

--- a/src/lib/utils/getClassName.js
+++ b/src/lib/utils/getClassName.js
@@ -1,6 +1,6 @@
 export default function getClassName(classesObj) {
-  const classNames = Object.keys(classesObj).filter(key => classesObj[key]);
-  const classString = classNames.join(' ');
-
-  return classString;
+  return Object
+    .keys(classesObj)
+    .filter(key => classesObj[key])
+    .join(' ');
 }

--- a/src/lib/utils/getClassName.js
+++ b/src/lib/utils/getClassName.js
@@ -1,0 +1,6 @@
+export default function getClassName(classesObj) {
+  const classNames = Object.keys(classesObj).filter(key => classesObj[key]);
+  const classString = classNames.join(' ');
+
+  return classString;
+}


### PR DESCRIPTION
# Done
- Added the option to pass an `href` prop to Button, which will render an anchor tag instead of a button
- Added the option to pass either children (`<Button>Value</Button>`) or a value prop (`Button value="Value />`) for the Button text
- Added Function and Link stories to Storybook
- Wrote a small utility function (`getClassName.js`) that takes an object consisting of the different possible class names for the element to write the full class string. This also allows much more flexible custom styling
- Added extra tests for the Button component

# QA
- Pull code
- Run `yarn lint` and check there are no errors
- Run `yarn test` and ensure that all tests still pass
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Check that the Link story for Button renders an anchor tag with link, not a button
- Check that the Function story for Button executes a simple alert
- Check that the styling for all Button variants are in line with the [Vanilla docs](https://docs.vanillaframework.io/en/patterns/buttons)

# Fixes
Fixes #112 
  