### PR TITLE
114 update accordion tests

### DIFF
--- a/src/lib/components/Accordion/Accordion.stories.js
+++ b/src/lib/components/Accordion/Accordion.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { withKnobs, boolean, text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Accordion from './Accordion';
@@ -9,7 +9,7 @@ import AccordionItem from './AccordionItem';
 storiesOf('Accordion', module).addDecorator(withKnobs)
   .add('Default',
     withInfo('Side bar accordion, used in listing pages or as navigation. Can hold multiple navigation items or to be used as a filter of content. Use to hold filtering items (header and content if available). Do not use to display page content. Each tab styling can be changed to open or collapse using aria-expanded, set true for open and false to close. Using JS this can be changed and to point to what each tab controls via aria-controls. .p-accordion__panel visibility is effected by aria-hidden and again can be manipulated with JS.')(() => (
-      <Accordion>
+      <Accordion allowMultiple={boolean('Allow Multiple', false)}>
         <AccordionItem title={text('Title1', 'Title of Item 1')}>
           <p>
             {text('Text1', 'Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.')}
@@ -25,7 +25,48 @@ storiesOf('Accordion', module).addDecorator(withKnobs)
             {text('Text3', 'Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.')}
           </p>
         </AccordionItem>
-      </Accordion>
+      </Accordion>),
     ),
+  )
+  .add('Allow Multiple',
+    withInfo('You can override single-open-only behaviour (i.e. a true accordion) by adding the allowMultiple prop.')(() => (
+      <Accordion allowMultiple={boolean('Allow Multiple', true)}>
+        <AccordionItem title={text('Title1', 'Title of Item 1')}>
+          <p>
+            {text('Text1', 'Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.')}
+          </p>
+        </AccordionItem>
+        <AccordionItem title={text('Title2', 'Title of Item 2')}>
+          <p>
+            {text('Text2', 'Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.')}
+          </p>
+        </AccordionItem>
+        <AccordionItem title={text('Title3', 'Title of Item 3')}>
+          <p>
+            {text('Text3', 'Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.')}
+          </p>
+        </AccordionItem>
+      </Accordion>),
+    ),
+  )
+  .add('Pre-selected',
+    withInfo('You can pre-select panels to be open by default by adding the selected prop, which accepts a number or array of numbers (0-indexed).')(() => (
+      <Accordion selected={[2]} allowMultiple={boolean('Allow Multiple', false)}>
+        <AccordionItem title={text('Title1', 'Title of Item 1')}>
+          <p>
+            {text('Text1', 'Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.')}
+          </p>
+        </AccordionItem>
+        <AccordionItem title={text('Title2', 'Title of Item 2')}>
+          <p>
+            {text('Text2', 'Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.')}
+          </p>
+        </AccordionItem>
+        <AccordionItem title={text('Title3', 'Title of Item 3')}>
+          <p>
+            {text('Text3', 'Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.')}
+          </p>
+        </AccordionItem>
+      </Accordion>),
     ),
   );

--- a/src/lib/components/Accordion/Accordion.test.js
+++ b/src/lib/components/Accordion/Accordion.test.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+
 import Accordion from './Accordion';
 import AccordionItem from './AccordionItem';
 
-describe('Accordion component', () => {
-  it('should compare with a snapshot', () => {
-    const accordionComponent = ReactTestRenderer.create(
+describe('<Accordion>', () => {
+  it('renders Accordion with AccordionItems correctly', () => {
+    const accordion = ReactTestRenderer.create(
       <Accordion>
         <AccordionItem title="Title of Item 1">
           <p>Lorem Ipsum has been the industrys standard dummy text ever since
@@ -27,8 +29,84 @@ describe('Accordion component', () => {
         </AccordionItem>
       </Accordion>,
     );
-    const json = accordionComponent.toJSON();
+    const json = accordion.toJSON();
     expect(json).toMatchSnapshot();
+  });
+
+  it('opens an AccordionItem when clicked', () => {
+    const accordion = mount(
+      <Accordion>
+        <AccordionItem title="Accordion Title">
+          <p>Accordion Content</p>
+        </AccordionItem>
+      </Accordion>);
+
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(0);
+    expect(accordion.find('[aria-hidden=true]')).toHaveLength(1);
+
+    accordion.find('button').hostNodes().simulate('click');
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(1);
+    expect(accordion.find('[aria-hidden=true]')).toHaveLength(0);
+  });
+
+  it('only has maximum one AccordionItem open at a time if allowMultiple=false', () => {
+    const accordion = mount(
+      <Accordion>
+        <AccordionItem title="Accordion Title 1">
+          <p>Accordion Content 1</p>
+        </AccordionItem>
+        <AccordionItem title="Accordion Title 2">
+          <p>Accordion Content 2</p>
+        </AccordionItem>
+      </Accordion>);
+
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(0);
+
+    accordion.find('#accordion-button-0').hostNodes().simulate('click');
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(1);
+
+    accordion.find('#accordion-button-1').hostNodes().simulate('click');
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(1);
+
+    accordion.find('#accordion-button-1').hostNodes().simulate('click');
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(0);
+  });
+
+  it('allows multiple AccordionItems open at a time if allowMultiple=true', () => {
+    const accordion = mount(
+      <Accordion allowMultiple>
+        <AccordionItem title="Accordion Title 1">
+          <p>Accordion Content 1</p>
+        </AccordionItem>
+        <AccordionItem title="Accordion Title 2">
+          <p>Accordion Content 2</p>
+        </AccordionItem>
+      </Accordion>);
+
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(0);
+
+    accordion.find('#accordion-button-0').hostNodes().simulate('click');
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(1);
+
+    accordion.find('#accordion-button-1').hostNodes().simulate('click');
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(2);
+
+    accordion.find('#accordion-button-1').hostNodes().simulate('click');
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(1);
+  });
+
+  it('allows pre-selection of AccordionItems if selected prop provided', () => {
+    const accordion = mount(
+      <Accordion selected={[0]}>
+        <AccordionItem title="Accordion Title 1">
+          <p>Accordion Content 1</p>
+        </AccordionItem>
+        <AccordionItem title="Accordion Title 2">
+          <p>Accordion Content 2</p>
+        </AccordionItem>
+      </Accordion>);
+
+    expect(accordion.find('[aria-expanded=true]')).toHaveLength(1);
   });
 });
 

--- a/src/lib/components/Accordion/AccordionItem.js
+++ b/src/lib/components/Accordion/AccordionItem.js
@@ -1,43 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class AccordionItem extends React.Component {
-  constructor() {
-    super();
-    this.onClick = this.onClick.bind(this);
-  }
+const AccordionItem = (props) => {
+  const {
+    isOpen, onClick, index, title, children,
+  } = props;
 
-  onClick() {
-    this.props.onClick(this.props.index);
-  }
-
-  render() {
-    return (
-      <li className="p-accordion__group">
-        <button
-          className="p-accordion__tab"
-          id="status-tab"
-          role="tab"
-          aria-controls="#status"
-          aria-expanded={this.props.isOpen}
-          onClick={this.onClick}
-          onKeyDown={this.onClick}
-        >
-          { this.props.title }
-        </button>
-        <section
-          className="p-accordion__panel"
-          id="status"
-          role="tabpanel"
-          aria-hidden={!this.props.isOpen}
-          aria-labelledby="status-tab"
-        >
-          { this.props.children }
-        </section>
-      </li>
-    );
-  }
-}
+  return (
+    <li className="p-accordion__group">
+      <button
+        className="p-accordion__tab"
+        id={`accordion-button-${index}`}
+        role="tab"
+        aria-controls={`accordion-content-${index}`}
+        aria-expanded={isOpen}
+        onClick={() => onClick(index)}
+        onKeyDown={key => key === 'Enter' && onClick(index)}
+      >
+        { title }
+      </button>
+      <section
+        className="p-accordion__panel"
+        id={`accordion-content-${index}`}
+        role="tabpanel"
+        aria-hidden={!isOpen}
+        aria-labelledby={`accordion-button-${index}`}
+      >
+        { children }
+      </section>
+    </li>
+  );
+};
 
 AccordionItem.defaultProps = {
   index: 0,

--- a/src/lib/components/Accordion/__snapshots__/Accordion.test.js.snap
+++ b/src/lib/components/Accordion/__snapshots__/Accordion.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Accordion component should compare with a snapshot 1`] = `
+exports[`<Accordion> renders Accordion with AccordionItems correctly 1`] = `
 <aside
   className="p-accordion"
   role="tablist"
@@ -12,10 +12,10 @@ exports[`Accordion component should compare with a snapshot 1`] = `
       className="p-accordion__group"
     >
       <button
-        aria-controls="#status"
+        aria-controls="accordion-content-0"
         aria-expanded={false}
         className="p-accordion__tab"
-        id="status-tab"
+        id="accordion-button-0"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="tab"
@@ -24,9 +24,9 @@ exports[`Accordion component should compare with a snapshot 1`] = `
       </button>
       <section
         aria-hidden={true}
-        aria-labelledby="status-tab"
+        aria-labelledby="accordion-button-0"
         className="p-accordion__panel"
-        id="status"
+        id="accordion-content-0"
         role="tabpanel"
       >
         <p>
@@ -38,10 +38,10 @@ exports[`Accordion component should compare with a snapshot 1`] = `
       className="p-accordion__group"
     >
       <button
-        aria-controls="#status"
+        aria-controls="accordion-content-1"
         aria-expanded={false}
         className="p-accordion__tab"
-        id="status-tab"
+        id="accordion-button-1"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="tab"
@@ -50,9 +50,9 @@ exports[`Accordion component should compare with a snapshot 1`] = `
       </button>
       <section
         aria-hidden={true}
-        aria-labelledby="status-tab"
+        aria-labelledby="accordion-button-1"
         className="p-accordion__panel"
-        id="status"
+        id="accordion-content-1"
         role="tabpanel"
       >
         <p>
@@ -64,10 +64,10 @@ exports[`Accordion component should compare with a snapshot 1`] = `
       className="p-accordion__group"
     >
       <button
-        aria-controls="#status"
+        aria-controls="accordion-content-2"
         aria-expanded={false}
         className="p-accordion__tab"
-        id="status-tab"
+        id="accordion-button-2"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="tab"
@@ -76,9 +76,9 @@ exports[`Accordion component should compare with a snapshot 1`] = `
       </button>
       <section
         aria-hidden={true}
-        aria-labelledby="status-tab"
+        aria-labelledby="accordion-button-2"
         className="p-accordion__panel"
-        id="status"
+        id="accordion-content-2"
         role="tabpanel"
       >
         <p>


### PR DESCRIPTION
# Done
- Added the option to pass an `allowMultiple` prop to Accordion, which will allow multiple panels to be open at a time
- Added the option to pass a `selected` prop to Accordion, which will make selected panels open before mounting
- Reduced `AccordionItem` to a stateless functional component
- Added Allow Multiple and Pre-Selected stories to Storybook
- Wrote a small utility function (`getClassName.js`) that takes an object consisting of the different possible class names for the element to write the full class string. This also allows much more flexible custom styling
- Added extra tests for the Accordion component

# QA
- Pull code
- Run `yarn lint` and check there are no errors
- Run `yarn test` and ensure that all tests still pass
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Check that the AllowMultiple story for Accordion allows multiple Accordion panels to be open at once
- Check that the Pre-Selected story for Accordion shows one of the panels already open on load

# Fixes
Fixes #114 