### PR TITLE
98: Update storybook styling

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,19 +1,18 @@
 import React from 'react';
-import { configure, addDecorator, getStorybook, setAddon } from '@storybook/react';
+import { configure, getStorybook, setAddon, addDecorator } from '@storybook/react';
 import { setDefaults } from '@storybook/addon-info';
+import { withKnobs } from '@storybook/addon-knobs';
 import { setOptions } from '@storybook/addon-options';
 import createPercyAddon from '@percy-io/percy-storybook';
 
-const { percyAddon, serializeStories } = createPercyAddon();
-setAddon(percyAddon);
+function loadStories() {
+  addDecorator(withKnobs);
 
-configure(
-  () => {
-    const req = require.context('../src', true, /.stories.js$/);
-    req.keys().forEach((filename) => req(filename));
-  },
-  module
-);
+  const req = require.context('../src', true, /.stories.js$/);
+  req.keys().forEach((filename) => req(filename));
+}
+
+configure(loadStories, module);
 
 // addon-info
 setDefaults({
@@ -21,6 +20,8 @@ setDefaults({
 });
 
 // Percy snaps
+const { percyAddon, serializeStories } = createPercyAddon();
+setAddon(percyAddon);
 serializeStories(getStorybook);
 
 // override option defaults:

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -5,7 +5,21 @@ import { withKnobs } from '@storybook/addon-knobs';
 import { setOptions } from '@storybook/addon-options';
 import createPercyAddon from '@percy-io/percy-storybook';
 
+const storybookStyling = (storyFn) => {
+  const style = {
+    padding: '0 1.25rem',
+  }
+
+  return (
+    <div style= {style}>
+      { storyFn() }
+    </div>
+  )
+}
+
 function loadStories() {
+  // Set custom global decorators
+  addDecorator(storybookStyling);
   addDecorator(withKnobs);
 
   const req = require.context('../src', true, /.stories.js$/);

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.6.3.min.css" />
+<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.6.4.min.css" />

--- a/src/lib/components/Accordion/Accordion.stories.js
+++ b/src/lib/components/Accordion/Accordion.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Accordion from './Accordion';
 import AccordionItem from './AccordionItem';
 
-storiesOf('Accordion', module).addDecorator(withKnobs)
+storiesOf('Accordion', module)
   .add('Default',
     withInfo('Side bar accordion, used in listing pages or as navigation. Can hold multiple navigation items or to be used as a filter of content. Use to hold filtering items (header and content if available). Do not use to display page content. Each tab styling can be changed to open or collapse using aria-expanded, set true for open and false to close. Using JS this can be changed and to point to what each tab controls via aria-controls. .p-accordion__panel visibility is effected by aria-hidden and again can be manipulated with JS.')(() => (
       <Accordion allowMultiple={boolean('Allow Multiple', false)}>

--- a/src/lib/components/BlockQuote/BlockQuote.stories.js
+++ b/src/lib/components/BlockQuote/BlockQuote.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import BlockQuote from './BlockQuote';
 
-storiesOf('Block Quote', module).addDecorator(withKnobs)
+storiesOf('Block Quote', module)
   .add('Default',
     withInfo('Basic blockquotes and citations.')(() => (
       <BlockQuote

--- a/src/lib/components/Button/Button.stories.js
+++ b/src/lib/components/Button/Button.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Button from './Button';
 
-storiesOf('Buttons', module).addDecorator(withKnobs)
+storiesOf('Buttons', module)
   .add('Base',
     withInfo('A base button is usually used alongside a neutral button. Precedence for button type is: base < neutral < brand < negative < positive.')(() => (
       <Button

--- a/src/lib/components/Card/Card.stories.js
+++ b/src/lib/components/Card/Card.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Card from './Card';
@@ -8,7 +8,7 @@ import Strip from '../Strip/Strip';
 import StripColumn from '../Strip/StripColumn';
 import StripRow from '../Strip/StripRow';
 
-storiesOf('Card', module).addDecorator(withKnobs)
+storiesOf('Card', module)
   .add('Default',
     withInfo('The purpose of the basic card is to display information, without user interaction.')(() => (
       <Card

--- a/src/lib/components/CodeBlock/CodeBlock.stories.js
+++ b/src/lib/components/CodeBlock/CodeBlock.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import CodeBlock from './CodeBlock';
 
-storiesOf('Code Block', module).addDecorator(withKnobs)
+storiesOf('Code Block', module)
   .add('Default',
     withInfo('The Code Block component is used to display a large amount of code. The preferred prop is a single template literal, to preserve formatting. Alternatively, markup can be used but will be formatted automatically. When you refer to code inline with other text, use the <code> tag instead.')(() => (
       <CodeBlock numbered={boolean('Numbered', false)}>

--- a/src/lib/components/CodeSnippet/CodeSnippet.stories.js
+++ b/src/lib/components/CodeSnippet/CodeSnippet.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import CodeSnippet from './CodeSnippet';
 
-storiesOf('Code Snippet', module).addDecorator(withKnobs)
+storiesOf('Code Snippet', module)
   .add('Default',
     withInfo('Code snippet should be used when presenting the user with a small snippet of code that they will likely want to copy and paste.')(() =>
       <CodeSnippet value={text('Value', 'sudo apt-get update')} />,

--- a/src/lib/components/HeadingIcon/HeadingIcon.stories.js
+++ b/src/lib/components/HeadingIcon/HeadingIcon.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import HeadingIcon from './HeadingIcon';
 
-storiesOf('Heading Icon', module).addDecorator(withKnobs)
+storiesOf('Heading Icon', module)
   .add('Default',
     withInfo('The HeadingIcon component can be used to add an icon to a standard header.')(() => (
       <HeadingIcon

--- a/src/lib/components/Image/Image.stories.js
+++ b/src/lib/components/Image/Image.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Image from './Image';
 
-storiesOf('Image', module).addDecorator(withKnobs)
+storiesOf('Image', module)
   .add('Default',
     withInfo('Default Image component.')(() => (
       <Image

--- a/src/lib/components/Link/Link.stories.js
+++ b/src/lib/components/Link/Link.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Link from './Link';
 
-storiesOf('Link', module).addDecorator(withKnobs)
+storiesOf('Link', module)
   .add('Default',
     withInfo('The default Link component.')(() => (
       <Link

--- a/src/lib/components/List/List.stories.js
+++ b/src/lib/components/List/List.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
+import { text, boolean, select } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import List from './List';
@@ -8,7 +8,7 @@ import ListItem from './ListItem';
 
 const modifiers = [null, 'divided', 'inline', 'middot', 'split'];
 
-storiesOf('List', module).addDecorator(withKnobs)
+storiesOf('List', module)
   .add('Default',
     withInfo('If you want to display lists in a way that is more visually distinctive than the standard <ol> and <ul>, Vanilla has 7 list styles at your disposal.')(() => (
       <List modifier={select('Modifier', modifiers, null)}>

--- a/src/lib/components/Matrix/Matrix.stories.js
+++ b/src/lib/components/Matrix/Matrix.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Matrix from './Matrix';
 import MatrixItem from './MatrixItem';
 
-storiesOf('Matrix', module).addDecorator(withKnobs)
+storiesOf('Matrix', module)
   .add('Default',
     withInfo('The Matrix component can be useful to display a selection of items in a format that is less linear than a normal list, using an image to describe each item. MatrixItem components will display in one column on small screens. At resolutions above $breakpoint-medium, the Matrix switches to three items per row.')(() => (
       <Matrix>

--- a/src/lib/components/MediaObject/MediaObject.stories.js
+++ b/src/lib/components/MediaObject/MediaObject.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import MediaObject from './MediaObject';
 
-storiesOf('Media Object', module).addDecorator(withKnobs)
+storiesOf('Media Object', module)
   .add('Default',
     withInfo('The MediaObject component should be used to display events or articles.')(() => (
       <MediaObject

--- a/src/lib/components/Modal/Modal.stories.js
+++ b/src/lib/components/Modal/Modal.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Modal from './Modal';
@@ -36,7 +36,7 @@ class ModalExample extends React.Component {
   }
 }
 
-storiesOf('Modal', module).addDecorator(withKnobs)
+storiesOf('Modal', module)
   .add('Default',
     withInfo('The Modal component can be useful to overlay an area of the screen which can contain a prompt, dialog or interaction. Note that opening and closing the Modal requires props from a parent component, for example by adjusting it in the Knobs panel in Storybook.')(() => (
       <div>

--- a/src/lib/components/MutedHeading/MutedHeading.stories.js
+++ b/src/lib/components/MutedHeading/MutedHeading.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import MutedHeading from './MutedHeading';
 
-storiesOf('Muted Heading', module).addDecorator(withKnobs)
+storiesOf('Muted Heading', module)
   .add('Default',
     withInfo('The MutedHeading component can be used to introduce a collection of icons or images.')(() => (
       <MutedHeading>{text('Text', 'Muted heading')}</MutedHeading>),

--- a/src/lib/components/Notification/Notification.stories.js
+++ b/src/lib/components/Notification/Notification.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Notification from './Notification';
 
-storiesOf('Notification', module).addDecorator(withKnobs)
+storiesOf('Notification', module)
   .add('Default',
     withInfo('Notification components are used to display global information. A Notification will display at the top and fill the full width of the page. It can be default, info, caution, negative or position.')(() => (
       <Notification

--- a/src/lib/components/SteppedList/SteppedList.stories.js
+++ b/src/lib/components/SteppedList/SteppedList.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import SteppedList from './SteppedList';
 import SteppedListItem from './SteppedListItem';
 
-storiesOf('Stepped List', module).addDecorator(withKnobs)
+storiesOf('Stepped List', module)
   .add('Default',
     withInfo('If you want to display a list of items that form a set of steps — like a tutorial or instructions — you can use the SteppedList component. This component is best used in a <Strip light> component as the description sections are displayed in a white box.')(() => (
       <div style={{ maxWidth: '45em' }}>

--- a/src/lib/components/Strip/Strip.stories.js
+++ b/src/lib/components/Strip/Strip.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, text, select } from '@storybook/addon-knobs';
+import { boolean, text, select } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Strip from './Strip';
@@ -17,7 +17,7 @@ const images = [
 ];
 const paddings = [null, 'shallow', 'deep'];
 
-storiesOf('Strip', module).addDecorator(withKnobs)
+storiesOf('Strip', module)
   .add('Light',
     withInfo('The Strip component provides a full width container in which to wrap StripRow components. The default colour is "light".')(() => (
       <div style={{ maxWidth: '1030px' }}>

--- a/src/lib/components/Table/Table.stories.js
+++ b/src/lib/components/Table/Table.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Table from './Table';
@@ -39,7 +39,7 @@ const data = [
   }],
 ];
 
-storiesOf('Table', module).addDecorator(withKnobs)
+storiesOf('Table', module)
   .add('Static Table',
     withInfo('The Table component can be constructed in two ways - either manually using appropriate sub-components (TableRow and TableCell), or dynamically using two object props (data and columns). This is an example of a Static Table built manually.')(() => (
       <Table

--- a/src/lib/components/Tabs/Tabs.stories.js
+++ b/src/lib/components/Tabs/Tabs.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, number } from '@storybook/addon-knobs';
+import { text, number } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import Tabs from './Tabs';
@@ -13,7 +13,7 @@ const options = {
   step: 1,
 };
 
-storiesOf('Tabs', module).addDecorator(withKnobs)
+storiesOf('Tabs', module)
   .add('Default',
     withInfo('Use the Tabs component when there are multiple categories/views/panes of content, but there is the need to only show one pane at a time. Don’t use Tabs for pagination of content or cases involve viewing content, not navigating between groups of content.')(() => (
       <Tabs


### PR DESCRIPTION
# Done
- Changed the withKnobs addon to be a global decorator, so it is only set once in `.storybook/config.js` and not in every story
- Removed superfluous withKnobs decorators from stories
- Added a custom global decorator that styles the component div with padding
- Updated to vanilla 1.6.4

# QA
- Pull code
- Run `yarn lint` and check there are no errors
- Run `yarn test` and ensure that all tests still pass
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Check that padding has been added to the left and right of the component wrapper (i.e. they're not butted up against the component list or knobs panel)
- Check that knobs still work

# Fixes
Fixes #98 
  