### PR TITLE
105: Add Pagination and PaginationItem components

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.6.4.min.css" />
+<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.6.5.min.css" />

--- a/src/lib/components/Pagination/Pagination.js
+++ b/src/lib/components/Pagination/Pagination.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import PaginationItem from './PaginationItem';
+
+const Pagination = props => (
+  <div className="p-pagination">
+    { props.children }
+  </div>
+);
+
+Pagination.defaultProps = {
+  children: null,
+};
+
+Pagination.propTypes = {
+  children: (props, propName, componentName) => {
+    const prop = props[propName];
+    let error = null;
+
+    React.Children.forEach(prop, (child) => {
+      if (child.type !== PaginationItem) {
+        error = new Error(`${componentName} children should be of type "PaginationItem".`);
+      }
+    });
+
+    return error;
+  },
+};
+
+Pagination.displayName = 'Pagination';
+
+export default Pagination;

--- a/src/lib/components/Pagination/Pagination.stories.js
+++ b/src/lib/components/Pagination/Pagination.stories.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import Pagination from './Pagination';
+import PaginationItem from './PaginationItem';
+
+storiesOf('Pagination', module)
+  .add('Next',
+    withInfo('The Pagination component should be used to navigate from one article to the next or previous in a chronological fashion.')(() => (
+      <Pagination>
+        <PaginationItem
+          next={boolean('Next', true)}
+          previous={boolean('Previous', false)}
+          href={text('href', '')}
+          label={text('Label', 'Next')}
+          title={text('Title', 'Consectetur adipisicing elit')}
+        />
+      </Pagination>),
+    ),
+  )
+
+  .add('Previous',
+    withInfo('info')(() => (
+      <Pagination>
+        <PaginationItem
+          next={boolean('Next', false)}
+          previous={boolean('Previous', true)}
+          href={text('href', '')}
+          label={text('Label', 'Previous')}
+          title={text('Title', 'Lorem ipsum dolor sit amet')}
+        />
+      </Pagination>),
+    ),
+  )
+
+  .add('Both',
+    withInfo('info')(() => (
+      <Pagination>
+        <PaginationItem
+          previous
+          href={text('Prev href', '')}
+          label={text('Prev Label', 'Previous')}
+          title={text('Prev Title', 'Lorem ipsum dolor sit amet')}
+        />
+        <PaginationItem
+          next
+          href={text('Next href', '')}
+          label={text('Next Label', 'Next')}
+          title={text('Next Title', 'Consectetur adipisicing elit')}
+        />
+      </Pagination>),
+    ),
+  );

--- a/src/lib/components/Pagination/Pagination.test.js
+++ b/src/lib/components/Pagination/Pagination.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+import Pagination from './Pagination';
+import PaginationItem from './PaginationItem';
+
+describe('<Pagination>', () => {
+  it('renders default Pagination with PaginationItem correctly', () => {
+    const pagination = ReactTestRenderer.create(
+      <Pagination>
+        <PaginationItem />
+      </Pagination>,
+    );
+    const json = pagination.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders PaginationItem with next prop correctly', () => {
+    const pagination = ReactTestRenderer.create(
+      <Pagination>
+        <PaginationItem next />
+      </Pagination>,
+    );
+    const json = pagination.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders PaginationItem with previous prop correctly', () => {
+    const pagination = ReactTestRenderer.create(
+      <Pagination>
+        <PaginationItem previous />
+      </Pagination>,
+    );
+    const json = pagination.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/Pagination/PaginationItem.js
+++ b/src/lib/components/Pagination/PaginationItem.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PaginationItem = (props) => {
+  const {
+    href, label, next, previous, title,
+  } = props;
+
+  let className = 'p-pagination__link';
+
+  if (next) {
+    className += '--next';
+  } else if (previous) {
+    className += '--previous';
+  }
+
+  return (
+    <a className={className} href={href}>
+      <span className="p-pagination__label">{label}</span>
+      <span className="p-pagination__title">{title}</span>
+    </a>
+  );
+};
+
+PaginationItem.defaultProps = {
+  href: null,
+  label: '',
+  next: false,
+  previous: false,
+  title: '',
+};
+
+PaginationItem.propTypes = {
+  href: PropTypes.string,
+  label: PropTypes.string,
+  next: PropTypes.bool,
+  previous: PropTypes.bool,
+  title: PropTypes.string,
+};
+
+PaginationItem.displayName = 'PaginationItem';
+
+export default PaginationItem;

--- a/src/lib/components/Pagination/__snapshots__/Pagination.test.js.snap
+++ b/src/lib/components/Pagination/__snapshots__/Pagination.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Pagination> renders PaginationItem with next prop correctly 1`] = `
+<div
+  className="p-pagination"
+>
+  <a
+    className="p-pagination__link--next"
+    href={null}
+  >
+    <span
+      className="p-pagination__label"
+    >
+      
+    </span>
+    <span
+      className="p-pagination__title"
+    >
+      
+    </span>
+  </a>
+</div>
+`;
+
+exports[`<Pagination> renders PaginationItem with previous prop correctly 1`] = `
+<div
+  className="p-pagination"
+>
+  <a
+    className="p-pagination__link--previous"
+    href={null}
+  >
+    <span
+      className="p-pagination__label"
+    >
+      
+    </span>
+    <span
+      className="p-pagination__title"
+    >
+      
+    </span>
+  </a>
+</div>
+`;
+
+exports[`<Pagination> renders default Pagination with PaginationItem correctly 1`] = `
+<div
+  className="p-pagination"
+>
+  <a
+    className="p-pagination__link"
+    href={null}
+  >
+    <span
+      className="p-pagination__label"
+    >
+      
+    </span>
+    <span
+      className="p-pagination__title"
+    >
+      
+    </span>
+  </a>
+</div>
+`;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -27,6 +27,8 @@ import MediaObject from './components/MediaObject/MediaObject';
 import Modal from './components/Modal/Modal';
 import MutedHeading from './components/MutedHeading/MutedHeading';
 import Notification from './components/Notification/Notification';
+import Pagination from './components/Pagination/Pagination';
+import PaginationItem from './components/Pagination/PaginationItem';
 import SteppedList from './components/SteppedList/SteppedList';
 import SteppedListItem from './components/SteppedList/SteppedListItem';
 import Strip from './components/Strip/Strip';
@@ -43,5 +45,6 @@ export {
   Accordion, AccordionItem, BlockQuote, Breadcrumb, BreadcrumbItem, Button, Card, CodeBlock,
   CodeSnippet, DividerList, DividerListItem, Footer, FooterNav, FooterNavContainer, HeadingIcon,
   Image, InlineImages, Link, List, ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix,
-  MatrixItem, MediaObject, Modal, MutedHeading, Notification, SteppedList, SteppedListItem, Strip,
-  StripColumn, StripRow, Switch, Table, TableCell, TableRow, Tabs, TabsItem };
+  MatrixItem, MediaObject, Modal, MutedHeading, Notification, Pagination, PaginationItem,
+  SteppedList, SteppedListItem, Strip, StripColumn, StripRow, Switch, Table, TableCell, TableRow,
+  Tabs, TabsItem };


### PR DESCRIPTION
# Done
- Added [Pagination](https://docs.vanillaframework.io/en/patterns/pagination) component and PaginationItem subcomponent
- Added stories/knobs to Storybook
- Added snapshot tests
- Updated to Vanilla 1.6.5 (which fixed single direction pagination)

# QA
- Pull code
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Verify the Pagination component in Storybook matches the [Vanilla docs](https://docs.vanillaframework.io/en/patterns/pagination)

# Fixes
Fixes #105