### PR TITLE
103: Add Navigation, NavigationBanner and NavigationLink components

### DIFF
--- a/src/lib/components/Navigation/Navigation.js
+++ b/src/lib/components/Navigation/Navigation.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import NavigationBanner from './NavigationBanner';
+import NavigationLink from './NavigationLink';
+
+class Navigation extends React.Component {
+  render() {
+    const { children } = this.props;
+    const links = [];
+    let banner;
+
+    React.Children.forEach(children, (child) => {
+      if (child.type === NavigationBanner) {
+        banner = child;
+      } else if (child.type === NavigationLink) {
+        links.push(child);
+      }
+    });
+
+    return (
+      <header id="navigation" className="p-navigation">
+        { banner }
+        { links.length > 0 &&
+          <nav className="p-navigation__nav">
+            <ul className="p-navigation__links" role="menu">
+              { links }
+            </ul>
+          </nav>
+        }
+      </header>
+    );
+  }
+}
+
+Navigation.defaultProps = {
+  children: null,
+};
+
+Navigation.propTypes = {
+  children: (props, propName, componentName) => {
+    const prop = props[propName];
+    let error = null;
+    let count = 0;
+
+    React.Children.forEach(prop, (child) => {
+      if (child.type === NavigationBanner) {
+        count += 1;
+      }
+    });
+
+    if (count !== 1) {
+      error = new Error(`${componentName} should have exactly one child of type "NavigationBanner".`);
+    }
+
+    return error;
+  },
+};
+
+Navigation.displayName = 'Navigation';
+
+export default Navigation;

--- a/src/lib/components/Navigation/Navigation.stories.js
+++ b/src/lib/components/Navigation/Navigation.stories.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import Navigation from './Navigation';
+import NavigationBanner from './NavigationBanner';
+import NavigationLink from './NavigationLink';
+
+storiesOf('Navigation', module)
+  .add('Text Banner',
+    withInfo('The Navigation component can be added to the top of your sites. NavigationLink components are collapsed behind a "Menu" link in small screens and displayed horizontally on larger screens.')(() => (
+      <Navigation>
+        <NavigationBanner
+          href="#"
+          title={text('Title', 'Vanilla')}
+        />
+        <NavigationLink
+          selected={boolean('Selected1', true)}
+          href="#"
+          label={text('Label1', 'Link1')}
+        />
+        <NavigationLink
+          selected={boolean('Selected2', false)}
+          href="#"
+          label={text('Label2', 'Link2')}
+        />
+        <NavigationLink
+          selected={boolean('Selected3', false)}
+          href="#"
+          label={text('Label3', 'Link3')}
+        />
+      </Navigation>),
+    ),
+  )
+
+  .add('Logo Banner',
+    withInfo('A logo object prop can also be passed to NavigationBanner, which will replace a simple text banner.')(() => (
+      <Navigation>
+        <NavigationBanner
+          href="#"
+          logo={{
+            src: text('Logo src', 'https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg'),
+            alt: '',
+          }}
+        />
+        <NavigationLink
+          selected={boolean('Selected1', true)}
+          href="#"
+          label={text('Label1', 'Link1')}
+        />
+        <NavigationLink
+          selected={boolean('Selected2', false)}
+          href="#"
+          label={text('Label2', 'Link2')}
+        />
+        <NavigationLink
+          selected={boolean('Selected3', false)}
+          href="#"
+          label={text('Label3', 'Link3')}
+        />
+      </Navigation>),
+    ),
+  );

--- a/src/lib/components/Navigation/Navigation.test.js
+++ b/src/lib/components/Navigation/Navigation.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import Navigation from './Navigation';
+import NavigationBanner from './NavigationBanner';
+import NavigationLink from './NavigationLink';
+
+describe('<Navigation>', () => {
+  it('renders with a text-based NavigationBanner correctly', () => {
+    const navigation = ReactTestRenderer.create(
+      <Navigation>
+        <NavigationBanner href="#" title="Title" />
+      </Navigation>,
+    );
+    const json = navigation.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders with a logo-based NavigationBanner correctly', () => {
+    const navigation = ReactTestRenderer.create(
+      <Navigation>
+        <NavigationBanner
+          href="#"
+          logo={{ src: 'https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg', alt: '' }}
+        />
+      </Navigation>,
+    );
+    const json = navigation.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders with a single NavigationLink correctly', () => {
+    const navigation = ReactTestRenderer.create(
+      <Navigation>
+        <NavigationBanner href="#" title="Title" />
+        <NavigationLink href="#" label="Link1" />
+      </Navigation>,
+    );
+    const json = navigation.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders with multiple NavigationLinks correctly', () => {
+    const navigation = ReactTestRenderer.create(
+      <Navigation>
+        <NavigationBanner href="#" title="Title" />
+        <NavigationLink href="#" label="Link1" />
+        <NavigationLink href="#" label="Link2" />
+        <NavigationLink href="#" label="Link3" />
+      </Navigation>,
+    );
+    const json = navigation.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/Navigation/NavigationBanner.js
+++ b/src/lib/components/Navigation/NavigationBanner.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class NavigationBanner extends React.Component {
+  render() {
+    const {
+      href, logo, menuText, title,
+    } = this.props;
+
+    const Tag = href ? 'a' : 'div';
+
+    return (
+      <div className="p-navigation__banner">
+        <div className="p-navigation__logo">
+          <Tag className="p-navigation__link" href={href}>
+            {(logo.src ?
+              <img className="p-navigation__image" src={logo.src} alt={logo.alt} /> : title
+            )}
+          </Tag>
+        </div>
+        <a href="#navigation" className="p-navigation__toggle--open" title="menu">
+          { menuText.open }
+        </a>
+        <a href="#navigation-closed" className="p-navigation__toggle--close" title="close menu">
+          { menuText.close }
+        </a>
+      </div>
+    );
+  }
+}
+
+NavigationBanner.defaultProps = {
+  href: null,
+  logo: { src: null, alt: '' },
+  menuText: { open: 'Menu', close: 'Close menu' },
+  title: null,
+};
+
+NavigationBanner.propTypes = {
+  href: PropTypes.string,
+  logo: PropTypes.shape({ src: PropTypes.string, alt: PropTypes.string }),
+  menuText: PropTypes.shape({ open: PropTypes.string, close: PropTypes.string }),
+  title: PropTypes.string,
+};
+
+NavigationBanner.displayName = 'NavigationBanner';
+
+export default NavigationBanner;

--- a/src/lib/components/Navigation/NavigationLink.js
+++ b/src/lib/components/Navigation/NavigationLink.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+const NavigationLink = (props) => {
+  const { href, label, selected } = props;
+
+  const className = getClassName({
+    'p-navigation__link': true,
+    'is-selected': selected,
+  });
+
+  return (
+    <li className={className} role="menuitem">
+      <a href={href}>
+        {label}
+      </a>
+    </li>
+  );
+};
+
+NavigationLink.defaultProps = {
+  selected: false,
+};
+
+NavigationLink.propTypes = {
+  label: PropTypes.string.isRequired,
+  href: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+};
+
+NavigationLink.displayName = 'NavigationLink';
+
+export default NavigationLink;

--- a/src/lib/components/Navigation/__snapshots__/Navigation.test.js.snap
+++ b/src/lib/components/Navigation/__snapshots__/Navigation.test.js.snap
@@ -1,0 +1,207 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Navigation> renders with a logo-based NavigationBanner correctly 1`] = `
+<header
+  className="p-navigation"
+  id="navigation"
+>
+  <div
+    className="p-navigation__banner"
+  >
+    <div
+      className="p-navigation__logo"
+    >
+      <a
+        className="p-navigation__link"
+        href="#"
+      >
+        <img
+          alt=""
+          className="p-navigation__image"
+          src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg"
+        />
+      </a>
+    </div>
+    <a
+      className="p-navigation__toggle--open"
+      href="#navigation"
+      title="menu"
+    >
+      Menu
+    </a>
+    <a
+      className="p-navigation__toggle--close"
+      href="#navigation-closed"
+      title="close menu"
+    >
+      Close menu
+    </a>
+  </div>
+</header>
+`;
+
+exports[`<Navigation> renders with a single NavigationLink correctly 1`] = `
+<header
+  className="p-navigation"
+  id="navigation"
+>
+  <div
+    className="p-navigation__banner"
+  >
+    <div
+      className="p-navigation__logo"
+    >
+      <a
+        className="p-navigation__link"
+        href="#"
+      >
+        Title
+      </a>
+    </div>
+    <a
+      className="p-navigation__toggle--open"
+      href="#navigation"
+      title="menu"
+    >
+      Menu
+    </a>
+    <a
+      className="p-navigation__toggle--close"
+      href="#navigation-closed"
+      title="close menu"
+    >
+      Close menu
+    </a>
+  </div>
+  <nav
+    className="p-navigation__nav"
+  >
+    <ul
+      className="p-navigation__links"
+      role="menu"
+    >
+      <li
+        className="p-navigation__link"
+        role="menuitem"
+      >
+        <a
+          href="#"
+        >
+          Link1
+        </a>
+      </li>
+    </ul>
+  </nav>
+</header>
+`;
+
+exports[`<Navigation> renders with a text-based NavigationBanner correctly 1`] = `
+<header
+  className="p-navigation"
+  id="navigation"
+>
+  <div
+    className="p-navigation__banner"
+  >
+    <div
+      className="p-navigation__logo"
+    >
+      <a
+        className="p-navigation__link"
+        href="#"
+      >
+        Title
+      </a>
+    </div>
+    <a
+      className="p-navigation__toggle--open"
+      href="#navigation"
+      title="menu"
+    >
+      Menu
+    </a>
+    <a
+      className="p-navigation__toggle--close"
+      href="#navigation-closed"
+      title="close menu"
+    >
+      Close menu
+    </a>
+  </div>
+</header>
+`;
+
+exports[`<Navigation> renders with multiple NavigationLinks correctly 1`] = `
+<header
+  className="p-navigation"
+  id="navigation"
+>
+  <div
+    className="p-navigation__banner"
+  >
+    <div
+      className="p-navigation__logo"
+    >
+      <a
+        className="p-navigation__link"
+        href="#"
+      >
+        Title
+      </a>
+    </div>
+    <a
+      className="p-navigation__toggle--open"
+      href="#navigation"
+      title="menu"
+    >
+      Menu
+    </a>
+    <a
+      className="p-navigation__toggle--close"
+      href="#navigation-closed"
+      title="close menu"
+    >
+      Close menu
+    </a>
+  </div>
+  <nav
+    className="p-navigation__nav"
+  >
+    <ul
+      className="p-navigation__links"
+      role="menu"
+    >
+      <li
+        className="p-navigation__link"
+        role="menuitem"
+      >
+        <a
+          href="#"
+        >
+          Link1
+        </a>
+      </li>
+      <li
+        className="p-navigation__link"
+        role="menuitem"
+      >
+        <a
+          href="#"
+        >
+          Link2
+        </a>
+      </li>
+      <li
+        className="p-navigation__link"
+        role="menuitem"
+      >
+        <a
+          href="#"
+        >
+          Link3
+        </a>
+      </li>
+    </ul>
+  </nav>
+</header>
+`;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -26,6 +26,9 @@ import MatrixItem from './components/Matrix/MatrixItem';
 import MediaObject from './components/MediaObject/MediaObject';
 import Modal from './components/Modal/Modal';
 import MutedHeading from './components/MutedHeading/MutedHeading';
+import Navigation from './components/Navigation/Navigation';
+import NavigationBanner from './components/Navigation/NavigationBanner';
+import NavigationLink from './components/Navigation/NavigationLink';
 import Notification from './components/Notification/Notification';
 import Pagination from './components/Pagination/Pagination';
 import PaginationItem from './components/Pagination/PaginationItem';
@@ -45,6 +48,6 @@ export {
   Accordion, AccordionItem, BlockQuote, Breadcrumb, BreadcrumbItem, Button, Card, CodeBlock,
   CodeSnippet, DividerList, DividerListItem, Footer, FooterNav, FooterNavContainer, HeadingIcon,
   Image, InlineImages, Link, List, ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix,
-  MatrixItem, MediaObject, Modal, MutedHeading, Notification, Pagination, PaginationItem,
-  SteppedList, SteppedListItem, Strip, StripColumn, StripRow, Switch, Table, TableCell, TableRow,
-  Tabs, TabsItem };
+  MatrixItem, MediaObject, Modal, MutedHeading, Navigation, NavigationBanner, NavigationLink,
+  Notification, Pagination, PaginationItem, SteppedList, SteppedListItem, Strip, StripColumn,
+  StripRow, Switch, Table, TableCell, TableRow, Tabs, TabsItem };


### PR DESCRIPTION
# Done
- Added [Navigation](https://docs.vanillaframework.io/en/patterns/navigation) component and NavigationBanner and NavigationLink subcomponents
- Added stories/knobs to Storybook
- Added snapshot tests

# QA
- Pull code
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Verify the Navigation component in Storybook matches the [Vanilla docs](https://docs.vanillaframework.io/en/patterns/navigation)

# Notes
- The small screen dropdown has been implemented as in normal Vanilla - the 'Menu' button is an anchor tag, and the dropdown visibility is affected by the nav being targeted (i.e. `.p-navigation:target`). This is good because it doesn't require JS, but for use in React it doesn't make sense to limit JS use. An issue has been filed to add an option for button styling alongside anchor for the dropdown (see [here](https://github.com/vanilla-framework/vanilla-framework/issues/1548))
- Extra testing will be added once this is addressed

# Fixes
Fixes #103 