### PR TITLE
104: Add SideNav, SideNavBanner, SideNavGroup and SideNavLink components

### DIFF
--- a/src/lib/components/Link/Link.js
+++ b/src/lib/components/Link/Link.js
@@ -1,41 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
 
 const Link = (props) => {
-  let classArray = [];
+  const {
+    soft, strong, inverted, external, top,
+  } = props;
+  const customClasses = props.className;
 
-  if (props.soft) {
-    classArray = [...classArray, 'p-link--soft'];
-  }
+  const className = getClassName({
+    'p-link--soft': soft,
+    'p-link--strong': strong,
+    'p-link--inverted': inverted,
+    'p-link--external': external,
+    'p-top__link': top,
+    [`${customClasses}`]: customClasses,
+  });
 
-  if (props.strong) {
-    classArray = [...classArray, 'p-link--strong'];
-  }
-
-  if (props.inverted) {
-    classArray = [...classArray, 'p-link--inverted'];
-  }
-
-  if (props.external) {
-    classArray = [...classArray, 'p-link--external'];
-  }
-
-  const classString = classArray.join(' ');
-
-  if (props.top) {
+  if (top) {
     return (
       <div className="p-top">
-        <a href={props.href} className={`${classString} p-top__link`}>{props.children}</a>
+        <a href={props.href} className={className}>{props.children}</a>
       </div>
     );
   }
 
   return (
-    <a href={props.href} className={classString}>{props.children}</a>
+    <a href={props.href} className={className}>{props.children}</a>
   );
 };
 
 Link.defaultProps = {
+  className: '',
   soft: false,
   strong: false,
   inverted: false,
@@ -45,6 +41,7 @@ Link.defaultProps = {
 
 Link.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
   href: PropTypes.string.isRequired,
   soft: PropTypes.bool,
   strong: PropTypes.bool,

--- a/src/lib/components/Link/__snapshots__/Link.test.js.snap
+++ b/src/lib/components/Link/__snapshots__/Link.test.js.snap
@@ -30,7 +30,7 @@ exports[`Link component should accept modifiers correctly 1`] = `
     className="p-top"
   >
     <a
-      className=" p-top__link"
+      className="p-top__link"
       href="https://vanilla-framework.github.io/vanilla-framework-react/"
     >
       Back to top

--- a/src/lib/components/SideNav/SideNav.js
+++ b/src/lib/components/SideNav/SideNav.js
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import SideNavBanner from './SideNavBanner';
+
+class SideNav extends React.Component {
+  constructor() {
+    super();
+    this.handleMenuClick = this.handleMenuClick.bind(this);
+
+    this.state = { menuOpen: false };
+  }
+
+  handleMenuClick() {
+    const { menuOpen } = this.state;
+    this.setState({ menuOpen: !menuOpen });
+  }
+
+  render() {
+    const { children } = this.props;
+    const { menuOpen } = this.state;
+    const content = [];
+    let banner;
+
+    React.Children.forEach(children, (child) => {
+      if (child.type === SideNavBanner) {
+        banner = React.cloneElement(child, {
+          ...this.props,
+          onClick: this.handleMenuClick,
+          open: this.state.menuOpen,
+        });
+      } else {
+        content.push(child);
+      }
+    });
+
+    return (
+      <div className="p-navigation--sidebar">
+        { banner }
+        <div className={`sidebar__content u-no-margin--top ${menuOpen ? '' : 'u-hide'}`}>
+          <ul className="p-list">
+            { content }
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}
+
+SideNav.defaultProps = {
+  children: null,
+};
+
+SideNav.propTypes = {
+  children: (props, propName, componentName) => {
+    const prop = props[propName];
+    let error = null;
+    let count = 0;
+
+    React.Children.forEach(prop, (child) => {
+      if (child.type === SideNavBanner) {
+        count += 1;
+      }
+    });
+
+    if (count !== 1) {
+      error = new Error(`${componentName} should have exactly one child of type "SideNavBanner".`);
+    }
+
+    return error;
+  },
+};
+
+SideNav.displayName = 'SideNav';
+
+export default SideNav;

--- a/src/lib/components/SideNav/SideNav.stories.js
+++ b/src/lib/components/SideNav/SideNav.stories.js
@@ -1,0 +1,184 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { number, text } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import Link from '../Link/Link';
+import List from '../List/List';
+import ListItem from '../List/ListItem';
+import SideNav from './SideNav';
+import SideNavBanner from './SideNavBanner';
+import SideNavGroup from './SideNavGroup';
+import SideNavLink from './SideNavLink';
+
+const options = {
+  range: true,
+  min: 3,
+  max: 12,
+  step: 1,
+};
+
+storiesOf('SideNav', module)
+  .add('Text Banner',
+    withInfo('The SideNav component allows for navigation from a collapsing menu on the side of the page. It requires a SideNavBanner which contains a title/logo, optional tagline, and a space for the small screen burger menu. SideNavLinks can be placed directly inside SideNav, or inside a SideNavGroup to keep them under section titles. This example will expand to fill the space available to it so it needs to be used in conjunction with the grid to set the layout.')(() => (
+      <div className={`col-${number('Column size', 12, options)}`}>
+        <SideNav>
+          <SideNavBanner
+            href="#"
+            tagline={text('Tagline', 'Lorem ipsum')}
+            title={text('Title', 'Vanilla')}
+          />
+          <SideNavGroup label="Section title 1">
+            <SideNavLink href="#" label="Second level 1" />
+            <SideNavLink href="#" label="Second level 2" />
+            <SideNavGroup label="Second level 3">
+              <SideNavLink href="#" label="Third level 1" />
+              <SideNavLink href="#" label="Third level 2" />
+              <SideNavLink href="#" label="Third level 3" />
+              <SideNavLink href="#" label="Third level 4" />
+              <SideNavLink href="#" label="Third level 5" />
+            </SideNavGroup>
+            <SideNavLink href="#" label="Second level 4" />
+            <SideNavLink href="#" label="Second level 5" />
+          </SideNavGroup>
+          <SideNavGroup label="Section title 2">
+            <SideNavLink href="#" label="Second level 1" />
+            <SideNavLink href="#" label="Second level 2" />
+            <SideNavGroup label="Second level 3">
+              <SideNavLink href="#" label="Third level 1" />
+              <SideNavLink href="#" label="Third level 2" />
+              <SideNavLink href="#" label="Third level 3" />
+              <SideNavLink href="#" label="Third level 4" />
+              <SideNavLink href="#" label="Third level 5" />
+            </SideNavGroup>
+            <SideNavLink href="#" label="Second level 4" />
+            <SideNavLink href="#" label="Second level 5" />
+          </SideNavGroup>
+          <SideNavGroup label="Section title 3">
+            <SideNavLink href="#" label="Second level 1" />
+            <SideNavLink href="#" label="Second level 2" />
+            <SideNavGroup label="Second level 3">
+              <SideNavLink href="#" label="Third level 1" />
+              <SideNavLink href="#" label="Third level 2" />
+              <SideNavLink href="#" label="Third level 3" />
+              <SideNavLink href="#" label="Third level 4" />
+              <SideNavLink href="#" label="Third level 5" />
+            </SideNavGroup>
+            <SideNavLink href="#" label="Second level 4" />
+            <SideNavLink href="#" label="Second level 5" />
+          </SideNavGroup>
+          <SideNavLink href="#" label="First level 1" />
+          <hr />
+          <List>
+            <ListItem>
+              <Link external className="sidebar__link" href="#a">Supplementary link 1</Link>
+            </ListItem>
+            <ListItem>
+              <Link external className="sidebar__link" href="#a">Supplementary link 2</Link>
+            </ListItem>
+          </List>
+        </SideNav>
+      </div>),
+    ),
+  )
+
+  .add('Logo Banner',
+    withInfo('A logo object prop can also be passed to SideNavBanner, which will replace a simple text banner.')(() => (
+      <div className={`col-${number('Column size', 12, options)}`}>
+        <SideNav>
+          <SideNavBanner
+            href="#"
+            logo={{
+              src: text('Logo src', 'https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg'),
+              alt: '',
+            }}
+            tagline={text('Tagline', 'Documentation')}
+          />
+          <SideNavGroup label="Basics">
+            <SideNavLink href="#" label="Color" />
+            <SideNavLink href="#" label="Font" />
+            <SideNavLink href="#" label="Reset" />
+            <SideNavLink href="#" label="Spacing" />
+          </SideNavGroup>
+          <SideNavGroup label="Global layout">
+            <SideNavLink href="#" label="Breakpoints" />
+            <SideNavLink href="#" label="Grid" />
+            <SideNavLink href="#" label="Strip" />
+            <SideNavLink href="#" label="Structure" />
+          </SideNavGroup>
+          <SideNavGroup label="One-off layout">
+            <SideNavLink href="#" label="Alignment" />
+            <SideNavLink href="#" label="Clearfix" />
+            <SideNavLink href="#" label="Equal height" />
+            <SideNavLink href="#" label="Floats" />
+            <SideNavLink href="#" label="Hide" />
+            <SideNavLink href="#" label="Image position" />
+            <SideNavLink href="#" label="Margin collapse" />
+            <SideNavLink href="#" label="Off-screen elements" />
+            <SideNavLink href="#" label="Padding collapse" />
+            <SideNavLink href="#" label="Show" />
+            <SideNavLink href="#" label="Vertically center" />
+          </SideNavGroup>
+          <SideNavGroup label="Navigation">
+            <SideNavLink href="#" label="Accordion" />
+            <SideNavLink href="#" label="Aside" />
+            <SideNavLink href="#" label="Breadcrumbs" />
+            <SideNavLink href="#" label="Contextual menu" />
+            <SideNavLink href="#" label="Footer" />
+            <SideNavLink href="#" label="Global navigation" />
+            <SideNavLink href="#" label="Pagination" />
+            <SideNavLink href="#" label="Tabs" />
+          </SideNavGroup>
+          <SideNavGroup label="Page structure">
+            <SideNavLink href="#" label="Cards" />
+            <SideNavLink href="#" label="Divider list" />
+            <SideNavLink href="#" label="Heading icon" />
+            <SideNavLink href="#" label="Images" />
+            <SideNavLink href="#" label="Inline images" />
+            <SideNavLink href="#" label="Lists" />
+            <SideNavLink href="#" label="Matrix" />
+            <SideNavLink href="#" label="Media object" />
+            <SideNavLink href="#" label="Muted heading" />
+          </SideNavGroup>
+          <SideNavGroup label="Text">
+            <SideNavLink href="#" label="Code" />
+            <SideNavLink href="#" label="Code numbered" />
+            <SideNavLink href="#" label="Code snippet" />
+            <SideNavLink href="#" label="Typography" />
+            <SideNavLink href="#" label="Quotes" />
+          </SideNavGroup>
+          <SideNavGroup label="Interactive elements">
+            <SideNavLink href="#" label="Buttons" />
+            <SideNavLink href="#" label="Forms" />
+            <SideNavLink href="#" label="Form layout" />
+            <SideNavLink href="#" label="Form validation" />
+            <SideNavLink href="#" label="Links" />
+            <SideNavLink href="#" label="List tree" />
+            <SideNavLink href="#" label="Modal" />
+            <SideNavLink href="#" label="Notifications" />
+            <SideNavLink href="#" label="Search box" />
+            <SideNavLink href="#" label="Slider" />
+            <SideNavLink href="#" label="Switch" />
+            <SideNavLink href="#" label="Table" />
+            <SideNavLink href="#" label="Table sortable" />
+            <SideNavLink href="#" label="Table expanding" />
+            <SideNavLink href="#" label="Table mobile card" />
+            <SideNavLink href="#" label="Tooltips" />
+          </SideNavGroup>
+          <SideNavGroup label="Media">
+            <SideNavLink href="#" label="Animations" />
+            <SideNavLink href="#" label="Assets" />
+            <SideNavLink href="#" label="Embedded media" />
+            <SideNavLink href="#" label="Icons" />
+            <SideNavLink href="#" label="Spin" />
+          </SideNavGroup>
+          <hr />
+          <List>
+            <ListItem>
+              <Link external className="sidebar__link" href="https://vanillaframework.io">vanillaframework.io</Link>
+            </ListItem>
+          </List>
+        </SideNav>
+      </div>),
+    ),
+  );

--- a/src/lib/components/SideNav/SideNav.test.js
+++ b/src/lib/components/SideNav/SideNav.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+import SideNav from './SideNav';
+import SideNavBanner from './SideNavBanner';
+import SideNavGroup from './SideNavGroup';
+import SideNavLink from './SideNavLink';
+
+describe('<SideNav>', () => {
+  it('renders with a text-based SideNavBanner correctly', () => {
+    const sidenav = ReactTestRenderer.create(
+      <SideNav>
+        <SideNavBanner href="#" title="Title" />
+      </SideNav>,
+    );
+    const json = sidenav.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders with a logo-based SideNavBanner correctly', () => {
+    const sidenav = ReactTestRenderer.create(
+      <SideNav>
+        <SideNavBanner
+          href="#"
+          logo={{ src: 'https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg', alt: '' }}
+        />
+      </SideNav>,
+    );
+    const json = sidenav.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders with a single SideNavLink correctly', () => {
+    const sidenav = ReactTestRenderer.create(
+      <SideNav>
+        <SideNavBanner href="#" title="Title" />
+        <SideNavLink href="#" label="Link1" />
+      </SideNav>,
+    );
+    const json = sidenav.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders with multiple SideNavLinks correctly', () => {
+    const sidenav = ReactTestRenderer.create(
+      <SideNav>
+        <SideNavBanner href="#" title="Title" />
+        <SideNavLink href="#" label="Link1" />
+        <SideNavLink href="#" label="Link2" />
+        <SideNavLink href="#" label="Link3" />
+      </SideNav>,
+    );
+    const json = sidenav.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders with a SideNavGroup correctly', () => {
+    const sidenav = ReactTestRenderer.create(
+      <SideNav>
+        <SideNavBanner href="#" title="Title" />
+        <SideNavGroup label="Group">
+          <SideNavLink href="#" label="Link" />
+        </SideNavGroup>
+      </SideNav>,
+    );
+    const json = sidenav.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders with multiple SideNavGroups correctly', () => {
+    const sidenav = ReactTestRenderer.create(
+      <SideNav>
+        <SideNavBanner href="#" title="Title" />
+        <SideNavGroup label="Group1">
+          <SideNavLink href="#" label="Link1" />
+        </SideNavGroup>
+        <SideNavGroup label="Group2">
+          <SideNavLink href="#" label="Link2" />
+        </SideNavGroup>
+        <SideNavGroup label="Group3">
+          <SideNavLink href="#" label="Link3" />
+        </SideNavGroup>
+      </SideNav>,
+    );
+    const json = sidenav.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/SideNav/SideNavBanner.js
+++ b/src/lib/components/SideNav/SideNavBanner.js
@@ -26,16 +26,21 @@ class SideNavBanner extends React.Component {
             <div className="sidebar__cta mobile-col-2 u-align--right">
               <ul className="p-inline-list u-no-margin--top">
                 <li className="p-inline-list__item">
-                  {/* eslint-disable */}
                   <i
                     className={`p-icon--menu ${open ? 'u-hide' : ''}`}
                     onClick={onClick}
-                    aria-hidden="false"
+                    onKeyDown={key => key === 'Enter' && onClick}
+                    aria-hidden={open ? 'true' : 'false'}
+                    role="button"
+                    tabIndex={0}
                   />
                   <i
                     className={`p-icon--close ${open ? '' : 'u-hide'}`}
                     onClick={onClick}
-                    aria-hidden="true"
+                    onKeyDown={key => key === 'Enter' && onClick}
+                    aria-hidden={open ? 'false' : 'true'}
+                    role="button"
+                    tabIndex={0}
                   />
                 </li>
               </ul>

--- a/src/lib/components/SideNav/SideNavBanner.js
+++ b/src/lib/components/SideNav/SideNavBanner.js
@@ -12,7 +12,7 @@ class SideNavBanner extends React.Component {
     return (
       <header id="sidenav" role="banner">
         <div className="p-navigation__banner">
-          <div className="row">
+          <div className="row u-no-margin--left">
             <div className="mobile-col-2">
               <div className="p-navigation__logo">
                 <Tag className="p-navigation__link" href={href}>

--- a/src/lib/components/SideNav/SideNavBanner.js
+++ b/src/lib/components/SideNav/SideNavBanner.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class SideNavBanner extends React.Component {
+  render() {
+    const {
+      href, logo, onClick, open, tagline, title,
+    } = this.props;
+
+    const Tag = href ? 'a' : 'div';
+
+    return (
+      <header id="sidenav" role="banner">
+        <div className="p-navigation__banner">
+          <div className="row">
+            <div className="mobile-col-2">
+              <div className="p-navigation__logo">
+                <Tag className="p-navigation__link" href={href}>
+                  {(logo.src ?
+                    <img className="p-navigation__image" src={logo.src} alt={logo.alt} /> : title
+                  )}
+                </Tag>
+              </div>
+              {tagline && <span className="p-navigation__tagline">{tagline}</span>}
+            </div>
+            <div className="sidebar__cta mobile-col-2 u-align--right">
+              <ul className="p-inline-list u-no-margin--top">
+                <li className="p-inline-list__item">
+                  {/* eslint-disable */}
+                  <i
+                    className={`p-icon--menu ${open ? 'u-hide' : ''}`}
+                    onClick={onClick}
+                    aria-hidden="false"
+                  />
+                  <i
+                    className={`p-icon--close ${open ? '' : 'u-hide'}`}
+                    onClick={onClick}
+                    aria-hidden="true"
+                  />
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </header>
+    );
+  }
+}
+
+SideNavBanner.defaultProps = {
+  href: null,
+  logo: { src: null, alt: '' },
+  onClick: () => 1,
+  open: false,
+  tagline: '',
+  title: null,
+};
+
+SideNavBanner.propTypes = {
+  href: PropTypes.string,
+  logo: PropTypes.shape({ src: PropTypes.string, alt: PropTypes.string }),
+  onClick: PropTypes.func,
+  open: PropTypes.bool,
+  tagline: PropTypes.string,
+  title: PropTypes.string,
+};
+
+SideNavBanner.displayName = 'SideNavBanner';
+
+export default SideNavBanner;

--- a/src/lib/components/SideNav/SideNavGroup.js
+++ b/src/lib/components/SideNav/SideNavGroup.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+import SideNavLink from './SideNavLink';
+
+class SideNavGroup extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+
+    this.state = { selected: props.selected };
+  }
+
+  onClick(e) {
+    e.preventDefault();
+    const { selected } = this.state;
+    this.setState({ selected: !selected });
+  }
+
+  render() {
+    const { children, href, label } = this.props;
+    const { selected } = this.state;
+
+    const className = getClassName({
+      sidebar__link: true,
+      'is-selected': selected,
+    });
+
+    return (
+      <li>
+        <a className={className} href={href} onClick={this.onClick}>
+          { label }
+          <i className="p-icon--plus" />
+          <i className="p-icon--minus" />
+        </a>
+        <ul className="sidebar__second-level">
+          { children }
+        </ul>
+      </li>
+    );
+  }
+}
+
+SideNavGroup.defaultProps = {
+  children: null,
+  href: '#',
+  selected: false,
+};
+
+SideNavGroup.propTypes = {
+  children: (props, propName, componentName) => {
+    const prop = props[propName];
+    let error = null;
+
+    React.Children.forEach(prop, (child) => {
+      if (child.type !== SideNavLink) {
+        error = new Error(`${componentName} children should be of type "SideNavLink".`);
+      }
+    });
+
+    return error;
+  },
+  href: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+};
+
+SideNavGroup.displayName = 'SideNavGroup';
+
+export default SideNavGroup;

--- a/src/lib/components/SideNav/SideNavGroup.js
+++ b/src/lib/components/SideNav/SideNavGroup.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import getClassName from '../../utils/getClassName';
 
-import SideNavLink from './SideNavLink';
-
 class SideNavGroup extends React.Component {
   constructor(props) {
     super(props);
@@ -49,18 +47,7 @@ SideNavGroup.defaultProps = {
 };
 
 SideNavGroup.propTypes = {
-  children: (props, propName, componentName) => {
-    const prop = props[propName];
-    let error = null;
-
-    React.Children.forEach(prop, (child) => {
-      if (child.type !== SideNavLink) {
-        error = new Error(`${componentName} children should be of type "SideNavLink".`);
-      }
-    });
-
-    return error;
-  },
+  children: PropTypes.node,
   href: PropTypes.string,
   label: PropTypes.string.isRequired,
   selected: PropTypes.bool,

--- a/src/lib/components/SideNav/SideNavLink.js
+++ b/src/lib/components/SideNav/SideNavLink.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+const SideNavLink = (props) => {
+  const {
+    children, href, label, selected,
+  } = props;
+
+  const className = getClassName({
+    sidebar__link: true,
+    'is-selected': selected,
+  });
+
+  return (
+    <li>
+      <a className={className} href={href}>
+        {label}
+        {children}
+      </a>
+    </li>
+  );
+};
+
+SideNavLink.defaultProps = {
+  children: null,
+  selected: false,
+};
+
+SideNavLink.propTypes = {
+  children: PropTypes.node,
+  label: PropTypes.string.isRequired,
+  href: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+};
+
+SideNavLink.displayName = 'SideNavLink';
+
+export default SideNavLink;

--- a/src/lib/components/SideNav/__snapshots__/SideNav.test.js.snap
+++ b/src/lib/components/SideNav/__snapshots__/SideNav.test.js.snap
@@ -42,11 +42,17 @@ exports[`<SideNav> renders with a SideNavGroup correctly 1`] = `
                 aria-hidden="false"
                 className="p-icon--menu "
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
               <i
                 aria-hidden="true"
                 className="p-icon--close u-hide"
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
             </li>
           </ul>
@@ -138,11 +144,17 @@ exports[`<SideNav> renders with a logo-based SideNavBanner correctly 1`] = `
                 aria-hidden="false"
                 className="p-icon--menu "
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
               <i
                 aria-hidden="true"
                 className="p-icon--close u-hide"
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
             </li>
           </ul>
@@ -202,11 +214,17 @@ exports[`<SideNav> renders with a single SideNavLink correctly 1`] = `
                 aria-hidden="false"
                 className="p-icon--menu "
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
               <i
                 aria-hidden="true"
                 className="p-icon--close u-hide"
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
             </li>
           </ul>
@@ -275,11 +293,17 @@ exports[`<SideNav> renders with a text-based SideNavBanner correctly 1`] = `
                 aria-hidden="false"
                 className="p-icon--menu "
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
               <i
                 aria-hidden="true"
                 className="p-icon--close u-hide"
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
             </li>
           </ul>
@@ -339,11 +363,17 @@ exports[`<SideNav> renders with multiple SideNavGroups correctly 1`] = `
                 aria-hidden="false"
                 className="p-icon--menu "
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
               <i
                 aria-hidden="true"
                 className="p-icon--close u-hide"
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
             </li>
           </ul>
@@ -485,11 +515,17 @@ exports[`<SideNav> renders with multiple SideNavLinks correctly 1`] = `
                 aria-hidden="false"
                 className="p-icon--menu "
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
               <i
                 aria-hidden="true"
                 className="p-icon--close u-hide"
                 onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
               />
             </li>
           </ul>

--- a/src/lib/components/SideNav/__snapshots__/SideNav.test.js.snap
+++ b/src/lib/components/SideNav/__snapshots__/SideNav.test.js.snap
@@ -12,7 +12,7 @@ exports[`<SideNav> renders with a SideNavGroup correctly 1`] = `
       className="p-navigation__banner"
     >
       <div
-        className="row"
+        className="row u-no-margin--left"
       >
         <div
           className="mobile-col-2"
@@ -110,7 +110,7 @@ exports[`<SideNav> renders with a logo-based SideNavBanner correctly 1`] = `
       className="p-navigation__banner"
     >
       <div
-        className="row"
+        className="row u-no-margin--left"
       >
         <div
           className="mobile-col-2"
@@ -184,7 +184,7 @@ exports[`<SideNav> renders with a single SideNavLink correctly 1`] = `
       className="p-navigation__banner"
     >
       <div
-        className="row"
+        className="row u-no-margin--left"
       >
         <div
           className="mobile-col-2"
@@ -263,7 +263,7 @@ exports[`<SideNav> renders with a text-based SideNavBanner correctly 1`] = `
       className="p-navigation__banner"
     >
       <div
-        className="row"
+        className="row u-no-margin--left"
       >
         <div
           className="mobile-col-2"
@@ -333,7 +333,7 @@ exports[`<SideNav> renders with multiple SideNavGroups correctly 1`] = `
       className="p-navigation__banner"
     >
       <div
-        className="row"
+        className="row u-no-margin--left"
       >
         <div
           className="mobile-col-2"
@@ -485,7 +485,7 @@ exports[`<SideNav> renders with multiple SideNavLinks correctly 1`] = `
       className="p-navigation__banner"
     >
       <div
-        className="row"
+        className="row u-no-margin--left"
       >
         <div
           className="mobile-col-2"

--- a/src/lib/components/SideNav/__snapshots__/SideNav.test.js.snap
+++ b/src/lib/components/SideNav/__snapshots__/SideNav.test.js.snap
@@ -1,0 +1,533 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SideNav> renders with a SideNavGroup correctly 1`] = `
+<div
+  className="p-navigation--sidebar"
+>
+  <header
+    id="sidenav"
+    role="banner"
+  >
+    <div
+      className="p-navigation__banner"
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="mobile-col-2"
+        >
+          <div
+            className="p-navigation__logo"
+          >
+            <a
+              className="p-navigation__link"
+              href="#"
+            >
+              Title
+            </a>
+          </div>
+          
+        </div>
+        <div
+          className="sidebar__cta mobile-col-2 u-align--right"
+        >
+          <ul
+            className="p-inline-list u-no-margin--top"
+          >
+            <li
+              className="p-inline-list__item"
+            >
+              <i
+                aria-hidden="false"
+                className="p-icon--menu "
+                onClick={[Function]}
+              />
+              <i
+                aria-hidden="true"
+                className="p-icon--close u-hide"
+                onClick={[Function]}
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div
+    className="sidebar__content u-no-margin--top u-hide"
+  >
+    <ul
+      className="p-list"
+    >
+      <li>
+        <a
+          className="sidebar__link"
+          href="#"
+          onClick={[Function]}
+        >
+          Group
+          <i
+            className="p-icon--plus"
+          />
+          <i
+            className="p-icon--minus"
+          />
+        </a>
+        <ul
+          className="sidebar__second-level"
+        >
+          <li>
+            <a
+              className="sidebar__link"
+              href="#"
+            >
+              Link
+            </a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`<SideNav> renders with a logo-based SideNavBanner correctly 1`] = `
+<div
+  className="p-navigation--sidebar"
+>
+  <header
+    id="sidenav"
+    role="banner"
+  >
+    <div
+      className="p-navigation__banner"
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="mobile-col-2"
+        >
+          <div
+            className="p-navigation__logo"
+          >
+            <a
+              className="p-navigation__link"
+              href="#"
+            >
+              <img
+                alt=""
+                className="p-navigation__image"
+                src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg"
+              />
+            </a>
+          </div>
+          
+        </div>
+        <div
+          className="sidebar__cta mobile-col-2 u-align--right"
+        >
+          <ul
+            className="p-inline-list u-no-margin--top"
+          >
+            <li
+              className="p-inline-list__item"
+            >
+              <i
+                aria-hidden="false"
+                className="p-icon--menu "
+                onClick={[Function]}
+              />
+              <i
+                aria-hidden="true"
+                className="p-icon--close u-hide"
+                onClick={[Function]}
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div
+    className="sidebar__content u-no-margin--top u-hide"
+  >
+    <ul
+      className="p-list"
+    />
+  </div>
+</div>
+`;
+
+exports[`<SideNav> renders with a single SideNavLink correctly 1`] = `
+<div
+  className="p-navigation--sidebar"
+>
+  <header
+    id="sidenav"
+    role="banner"
+  >
+    <div
+      className="p-navigation__banner"
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="mobile-col-2"
+        >
+          <div
+            className="p-navigation__logo"
+          >
+            <a
+              className="p-navigation__link"
+              href="#"
+            >
+              Title
+            </a>
+          </div>
+          
+        </div>
+        <div
+          className="sidebar__cta mobile-col-2 u-align--right"
+        >
+          <ul
+            className="p-inline-list u-no-margin--top"
+          >
+            <li
+              className="p-inline-list__item"
+            >
+              <i
+                aria-hidden="false"
+                className="p-icon--menu "
+                onClick={[Function]}
+              />
+              <i
+                aria-hidden="true"
+                className="p-icon--close u-hide"
+                onClick={[Function]}
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div
+    className="sidebar__content u-no-margin--top u-hide"
+  >
+    <ul
+      className="p-list"
+    >
+      <li>
+        <a
+          className="sidebar__link"
+          href="#"
+        >
+          Link1
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`<SideNav> renders with a text-based SideNavBanner correctly 1`] = `
+<div
+  className="p-navigation--sidebar"
+>
+  <header
+    id="sidenav"
+    role="banner"
+  >
+    <div
+      className="p-navigation__banner"
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="mobile-col-2"
+        >
+          <div
+            className="p-navigation__logo"
+          >
+            <a
+              className="p-navigation__link"
+              href="#"
+            >
+              Title
+            </a>
+          </div>
+          
+        </div>
+        <div
+          className="sidebar__cta mobile-col-2 u-align--right"
+        >
+          <ul
+            className="p-inline-list u-no-margin--top"
+          >
+            <li
+              className="p-inline-list__item"
+            >
+              <i
+                aria-hidden="false"
+                className="p-icon--menu "
+                onClick={[Function]}
+              />
+              <i
+                aria-hidden="true"
+                className="p-icon--close u-hide"
+                onClick={[Function]}
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div
+    className="sidebar__content u-no-margin--top u-hide"
+  >
+    <ul
+      className="p-list"
+    />
+  </div>
+</div>
+`;
+
+exports[`<SideNav> renders with multiple SideNavGroups correctly 1`] = `
+<div
+  className="p-navigation--sidebar"
+>
+  <header
+    id="sidenav"
+    role="banner"
+  >
+    <div
+      className="p-navigation__banner"
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="mobile-col-2"
+        >
+          <div
+            className="p-navigation__logo"
+          >
+            <a
+              className="p-navigation__link"
+              href="#"
+            >
+              Title
+            </a>
+          </div>
+          
+        </div>
+        <div
+          className="sidebar__cta mobile-col-2 u-align--right"
+        >
+          <ul
+            className="p-inline-list u-no-margin--top"
+          >
+            <li
+              className="p-inline-list__item"
+            >
+              <i
+                aria-hidden="false"
+                className="p-icon--menu "
+                onClick={[Function]}
+              />
+              <i
+                aria-hidden="true"
+                className="p-icon--close u-hide"
+                onClick={[Function]}
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div
+    className="sidebar__content u-no-margin--top u-hide"
+  >
+    <ul
+      className="p-list"
+    >
+      <li>
+        <a
+          className="sidebar__link"
+          href="#"
+          onClick={[Function]}
+        >
+          Group1
+          <i
+            className="p-icon--plus"
+          />
+          <i
+            className="p-icon--minus"
+          />
+        </a>
+        <ul
+          className="sidebar__second-level"
+        >
+          <li>
+            <a
+              className="sidebar__link"
+              href="#"
+            >
+              Link1
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <a
+          className="sidebar__link"
+          href="#"
+          onClick={[Function]}
+        >
+          Group2
+          <i
+            className="p-icon--plus"
+          />
+          <i
+            className="p-icon--minus"
+          />
+        </a>
+        <ul
+          className="sidebar__second-level"
+        >
+          <li>
+            <a
+              className="sidebar__link"
+              href="#"
+            >
+              Link2
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <a
+          className="sidebar__link"
+          href="#"
+          onClick={[Function]}
+        >
+          Group3
+          <i
+            className="p-icon--plus"
+          />
+          <i
+            className="p-icon--minus"
+          />
+        </a>
+        <ul
+          className="sidebar__second-level"
+        >
+          <li>
+            <a
+              className="sidebar__link"
+              href="#"
+            >
+              Link3
+            </a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`<SideNav> renders with multiple SideNavLinks correctly 1`] = `
+<div
+  className="p-navigation--sidebar"
+>
+  <header
+    id="sidenav"
+    role="banner"
+  >
+    <div
+      className="p-navigation__banner"
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="mobile-col-2"
+        >
+          <div
+            className="p-navigation__logo"
+          >
+            <a
+              className="p-navigation__link"
+              href="#"
+            >
+              Title
+            </a>
+          </div>
+          
+        </div>
+        <div
+          className="sidebar__cta mobile-col-2 u-align--right"
+        >
+          <ul
+            className="p-inline-list u-no-margin--top"
+          >
+            <li
+              className="p-inline-list__item"
+            >
+              <i
+                aria-hidden="false"
+                className="p-icon--menu "
+                onClick={[Function]}
+              />
+              <i
+                aria-hidden="true"
+                className="p-icon--close u-hide"
+                onClick={[Function]}
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div
+    className="sidebar__content u-no-margin--top u-hide"
+  >
+    <ul
+      className="p-list"
+    >
+      <li>
+        <a
+          className="sidebar__link"
+          href="#"
+        >
+          Link1
+        </a>
+      </li>
+      <li>
+        <a
+          className="sidebar__link"
+          href="#"
+        >
+          Link2
+        </a>
+      </li>
+      <li>
+        <a
+          className="sidebar__link"
+          href="#"
+        >
+          Link3
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -32,6 +32,9 @@ import NavigationLink from './components/Navigation/NavigationLink';
 import Notification from './components/Notification/Notification';
 import Pagination from './components/Pagination/Pagination';
 import PaginationItem from './components/Pagination/PaginationItem';
+import SideNav from './components/SideNav/SideNav';
+import SideNavBanner from './components/SideNav/SideNavBanner';
+import SideNavLink from './components/SideNav/SideNavLink';
 import SteppedList from './components/SteppedList/SteppedList';
 import SteppedListItem from './components/SteppedList/SteppedListItem';
 import Strip from './components/Strip/Strip';
@@ -49,5 +52,6 @@ export {
   CodeSnippet, DividerList, DividerListItem, Footer, FooterNav, FooterNavContainer, HeadingIcon,
   Image, InlineImages, Link, List, ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix,
   MatrixItem, MediaObject, Modal, MutedHeading, Navigation, NavigationBanner, NavigationLink,
-  Notification, Pagination, PaginationItem, SteppedList, SteppedListItem, Strip, StripColumn,
-  StripRow, Switch, Table, TableCell, TableRow, Tabs, TabsItem };
+  Notification, Pagination, PaginationItem, SideNav, SideNavBanner, SideNavLink, SteppedList,
+  SteppedListItem, Strip, StripColumn, StripRow, Switch, Table, TableCell, TableRow, Tabs, TabsItem,
+};

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -34,6 +34,7 @@ import Pagination from './components/Pagination/Pagination';
 import PaginationItem from './components/Pagination/PaginationItem';
 import SideNav from './components/SideNav/SideNav';
 import SideNavBanner from './components/SideNav/SideNavBanner';
+import SideNavGroup from './components/SideNav/SideNavGroup';
 import SideNavLink from './components/SideNav/SideNavLink';
 import SteppedList from './components/SteppedList/SteppedList';
 import SteppedListItem from './components/SteppedList/SteppedListItem';
@@ -52,6 +53,7 @@ export {
   CodeSnippet, DividerList, DividerListItem, Footer, FooterNav, FooterNavContainer, HeadingIcon,
   Image, InlineImages, Link, List, ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix,
   MatrixItem, MediaObject, Modal, MutedHeading, Navigation, NavigationBanner, NavigationLink,
-  Notification, Pagination, PaginationItem, SideNav, SideNavBanner, SideNavLink, SteppedList,
-  SteppedListItem, Strip, StripColumn, StripRow, Switch, Table, TableCell, TableRow, Tabs, TabsItem,
+  Notification, Pagination, PaginationItem, SideNav, SideNavBanner, SideNavGroup, SideNavLink,
+  SteppedList, SteppedListItem, Strip, StripColumn, StripRow, Switch, Table, TableCell, TableRow,
+  Tabs, TabsItem,
 };


### PR DESCRIPTION
# Done
- Added [SideNav](https://docs.vanillaframework.io/en/patterns/navigation#sidebar-navigation) component and SideNavBanner, SideNavGroup, and SideNavLink subcomponents
- Added stories/knobs to Storybook
- Added snapshot tests
- Updated Link component with `getClassName` util

# QA
- Pull code
- Run `yarn lint` and `yarn test` to ensure there are no linting or testing errors
- Run `./run serve --watch` and navigate to http://localhost:8102/
- Verify the SideNav component in Storybook matches the [Vanilla docs](https://docs.vanillaframework.io/en/patterns/navigation#sidebar-navigation)
- Check that it operates as expected (groups open/close, on small screens the burger menu expands, etc.)

# Notes
- There are some styling bugs with current Vanilla (1.6.5) that will hopefully be fixed in the next release
  - `.sidebar__content` has `position: absolute`, so it overlaps the Storybook content a bit.
  - when inside a large column (e.g. `col-12`), the title and tagline move away from the left, so a `u-no-margin--left` utility has been added to the banner row div

# Fixes
Fixes #104 