### PR TITLE
Add Form, Input and associated components to Vanilla React

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.6.5.min.css" />
+<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.6.6.min.css" />

--- a/src/lib/components/Button/Button.js
+++ b/src/lib/components/Button/Button.js
@@ -23,12 +23,13 @@ class Button extends React.Component {
 
   render() {
     const {
-      children, value, disabled, href, positive, negative, brand, neutral, inline,
+      children, className, value, disabled, href, positive,
+      negative, brand, neutral, inline, ...otherProps
     } = this.props;
     const Tag = href ? 'a' : 'button';
 
     const customClasses = this.props.className;
-    const className = getClassName({
+    const classNames = getClassName({
       'p-button--base': !(positive || negative || brand || neutral),
       'p-button--neutral': neutral,
       'p-button--positive': positive,
@@ -41,10 +42,11 @@ class Button extends React.Component {
 
     return (
       <Tag
-        className={className}
+        className={classNames}
         href={Tag === 'a' ? href : undefined}
         onClick={this.onClick}
         disabled={disabled}
+        {...otherProps}
       >
         { value || children }
       </Tag>

--- a/src/lib/components/Button/Button.js
+++ b/src/lib/components/Button/Button.js
@@ -28,8 +28,8 @@ class Button extends React.Component {
     } = this.props;
     const Tag = href ? 'a' : 'button';
 
-    const customClasses = this.props.className;
     const classNames = getClassName({
+      [className]: className,
       'p-button--base': !(positive || negative || brand || neutral),
       'p-button--neutral': neutral,
       'p-button--positive': positive,
@@ -37,8 +37,7 @@ class Button extends React.Component {
       'p-button--brand': brand,
       'is-inline': inline,
       'is--disabled': disabled,
-      [`${customClasses}`]: customClasses,
-    });
+    }) || undefined;
 
     return (
       <Tag

--- a/src/lib/components/Form/FieldSet.js
+++ b/src/lib/components/Form/FieldSet.js
@@ -6,8 +6,8 @@ const FieldSet = (props) => {
   const { children, className, ...otherProps } = props;
 
   const classNames = getClassName({
-    [`${className}`]: className,
-  });
+    [className]: className,
+  }) || undefined;
 
   return (
     <fieldset className={classNames} {...otherProps}>

--- a/src/lib/components/Form/FieldSet.js
+++ b/src/lib/components/Form/FieldSet.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+const FieldSet = (props) => {
+  const { children, className, ...otherProps } = props;
+
+  const classNames = getClassName({
+    [`${className}`]: className,
+  });
+
+  return (
+    <fieldset className={classNames} {...otherProps}>
+      { children }
+    </fieldset>
+  );
+};
+
+FieldSet.defaultProps = {
+  className: undefined,
+};
+
+FieldSet.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
+FieldSet.displayName = 'FieldSet';
+
+export default FieldSet;

--- a/src/lib/components/Form/Form.js
+++ b/src/lib/components/Form/Form.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+const Form = (props) => {
+  const {
+    children, className, inline, stacked, ...otherProps
+  } = props;
+
+  const classNames = getClassName({
+    'p-form': true,
+    'p-form--inline': inline && !stacked,
+    'p-form--stacked': stacked && !inline,
+    [`${className}`]: className,
+  }) || undefined;
+
+  return (
+    <form className={classNames} {...otherProps}>
+      {children}
+    </form>
+  );
+};
+
+Form.defaultProps = {
+  children: null,
+  className: undefined,
+  inline: false,
+  stacked: false,
+};
+
+Form.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  inline: PropTypes.bool,
+  stacked: PropTypes.bool,
+};
+
+Form.displayName = 'Form';
+
+export default Form;

--- a/src/lib/components/Form/Form.js
+++ b/src/lib/components/Form/Form.js
@@ -8,10 +8,10 @@ const Form = (props) => {
   } = props;
 
   const classNames = getClassName({
+    [className]: className,
     'p-form': true,
     'p-form--inline': inline && !stacked,
     'p-form--stacked': stacked && !inline,
-    [`${className}`]: className,
   }) || undefined;
 
   return (

--- a/src/lib/components/Form/Form.stories.js
+++ b/src/lib/components/Form/Form.stories.js
@@ -1,0 +1,252 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text, select } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import Form from './Form';
+import FormControl from './FormControl';
+import FormGroup from './FormGroup';
+import FieldSet from './FieldSet';
+import Input from '../Input/Input';
+import Label from '../Input/Label';
+import Button from '../Button/Button';
+
+const inputTypes = [
+  'text', 'password', 'file', 'hidden', 'date', 'month', 'select', 'textarea',
+  'time', 'week', 'number', 'email', 'url', 'tel',
+];
+
+const exampleSubmit = (event) => {
+  event.preventDefault();
+  alert('You submitted the form!'); // eslint-disable-line no-alert
+};
+
+class ValidationExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.getValidationState = this.getValidationState.bind(this);
+
+    this.state = {
+      value: '',
+    };
+  }
+
+  getValidationState() {
+    const { length } = this.state.value;
+    if (length > 7) return { status: 'success', tag: 'Success: ', message: 'Username length OK' };
+    else if (length > 3) return { status: 'caution', tag: 'Warning: ', message: 'A little bit longer...' };
+    else if (length > 0) return { status: 'error', tag: 'Error: ', message: 'Username is too short' };
+    return { status: null, tag: null, message: null };
+  }
+
+  handleChange(event) {
+    this.setState({ value: event.target.value });
+  }
+
+  render() {
+    return (
+      <Form onSubmit={exampleSubmit}>
+        <FormControl
+          help="Username must be at least 8 characters long"
+          validation={this.getValidationState()}
+        >
+          <Label htmlFor="exampleInput">Username</Label>
+          <Input
+            type="text"
+            id="exampleInput"
+            value={this.state.value}
+            placeholder="Enter username"
+            onInput={this.handleChange}
+          />
+        </FormControl>
+        <Button positive type="submit">Register</Button>
+      </Form>
+    );
+  }
+}
+
+storiesOf('Form', module)
+  .add('Default',
+    withInfo('Vanilla form controls have global styling defined at the HTML element level. Labels and most input types are 100% width of the <Form> parent element.')(() => (
+      <Form onSubmit={exampleSubmit}>
+        <Label htmlFor="input1">Text input</Label>
+        <Input type="text" id="input1" placeholder="Enter text here" />
+        <Label htmlFor="input2">Password input</Label>
+        <Input type="password" id="input2" placeholder="Enter password here" />
+        <Input type="radio" id="input3" name="radios" value="radio1" />
+        <Label htmlFor="input3">Radio button 1</Label>
+        <Input type="radio" id="input4" name="radios" value="radio2" />
+        <Label htmlFor="input4">Radio button 2</Label>
+        <Input type="checkbox" id="input5" name="checkboxes" value="checkbox1" />
+        <Label htmlFor="input5">Checkbox 1</Label>
+        <Input type="checkbox" id="input6" name="checkboxes" value="checkbox2" />
+        <Label htmlFor="input6">Checkbox 2</Label>
+        <Input type="checkbox" id="input7" name="checkboxes" value="checkbox3" />
+        <Label htmlFor="input7">Checkbox 3</Label>
+        <Label htmlFor="input8">Textarea</Label>
+        <Input type="textarea" id="input8" rows="4" placeholder="Enter text here" />
+        <Label htmlFor="input9">Select</Label>
+        <Input type="select" id="input9" name="selects" defaultValue="">
+          <option value="" disabled>Select an option</option>
+          <option value="option1">Option 1</option>
+          <option value="option2">Option 2</option>
+          <option value="option3">Option 3</option>
+        </Input>
+        <Label htmlFor="input10">Choose a file</Label>
+        <Input type="file" id="input10" />
+        <Button positive type="submit">Submit</Button>
+      </Form>),
+    ),
+  )
+
+  .add('FieldSet',
+    withInfo('You can use the <FieldSet> element to divide the form into different logical sections.')(() => (
+      <Form>
+        <FieldSet>
+          <Label htmlFor="input1">Input 1</Label>
+          <Input type="text" id="input1" />
+          <Label htmlFor="input2">Input 2</Label>
+          <Input type="text" id="input2" />
+          <Label htmlFor="input3">Input 3</Label>
+          <Input type="text" id="input3" />
+        </FieldSet>
+        <FieldSet>
+          <Label htmlFor="input4">Input 4</Label>
+          <Input type="textarea" id="input4" rows="6" />
+        </FieldSet>
+      </Form>),
+    ),
+  )
+
+  .add('FormControl',
+    withInfo('The <FormControl> component renders a form control with Vanilla styling, allowing support for help text and validation.')(() => (
+      <Form onSubmit={exampleSubmit}>
+        <FormControl
+          help={text('Help text', 'This is some helpful text!')}
+          validation={{
+            status: select('Validation state', ['', 'success', 'caution', 'error'], 'success'),
+            tag: text('Validation tag', 'Success: '),
+            message: text('Validation text', 'You did something right!'),
+          }}
+        >
+          <Label htmlFor="input1">Text input</Label>
+          <Input
+            type={select('Input type', inputTypes, 'text')}
+            id="textInput1"
+            placeholder={text('Placeholder', 'Enter text here')}
+            maxLength={text('Max length', '')}
+            required={boolean('Required', false)}
+            disabled={boolean('Disabled', false)}
+          />
+        </FormControl>
+        <Button positive type="submit">Submit</Button>
+      </Form>),
+    ),
+  )
+
+  .add('Validation example',
+    withInfo('This is an example of form validation being used based on username length.')(() => (
+      <ValidationExample />),
+    ),
+  )
+
+  .add('Inline',
+    withInfo('Forms can be made inline by adding the "inline" prop to <Form>. Note that each <Label> and associated <FormControl> are wrapped in a <FormGroup> component in order to apply styling correctly.')(() => (
+      <div>
+        <Form
+          inline
+          onSubmit={exampleSubmit}
+        >
+          <FormGroup>
+            <Label htmlFor="exampleInput1">First name</Label>
+            <FormControl help="A rose by any other name would smell as sweet.">
+              <Input type="text" id="exampleInput1" defaultValue="William" />
+            </FormControl>
+          </FormGroup>
+          <FormGroup>
+            <Label htmlFor="exampleInput2">Last name</Label>
+            <FormControl
+              validation={{
+                status: 'caution',
+                tag: 'Nice try: ',
+                message: 'You almost spelt it correctly!',
+              }}
+            >
+              <Input type="text" id="exampleInput2" defaultValue="Shakespare" />
+            </FormControl>
+          </FormGroup>
+          <Button positive type="submit">Add details</Button>
+        </Form>
+      </div>),
+    ),
+  )
+
+  .add('Stacked',
+    withInfo('Forms can be stacked by adding the "stacked" prop to <Form>. Note that each <Label> and associated <FormControl> are wrapped in a <FormGroup> component in order to apply styling correctly.')(() => (
+      <Form stacked onSubmit={exampleSubmit}>
+        <FormGroup>
+          <Label htmlFor="input1">Username</Label>
+          <FormControl
+            help="Usernames must be all lowercase."
+            validation={{
+              status: 'success',
+              tag: 'Success: ',
+              message: 'Everything looks good!',
+            }}
+          >
+            <Input type="text" id="input1" defaultValue="username" />
+          </FormControl>
+        </FormGroup>
+        <FormGroup>
+          <Label htmlFor="input2">Password</Label>
+          <FormControl
+            validation={{
+              status: 'caution',
+              message: 'Passwords require at least one symbol.',
+            }}
+          >
+            <Input type="password" id="input2" defaultValue="qwerty123" />
+          </FormControl>
+        </FormGroup>
+        <FormGroup>
+          <Label htmlFor="input3">Address</Label>
+          <FormControl
+            validation={{
+              status: 'error',
+              tag: 'Error: ',
+              message: 'Unable to locate address.',
+            }}
+          >
+            <Input type="text" id="input3" defaultValue="1234 Five St" />
+          </FormControl>
+        </FormGroup>
+        <FormGroup>
+          <Label htmlFor="input8">Additional comments</Label>
+          <FormControl help="This text is more helpful than you think.">
+            <Input type="textarea" id="input8" rows="4" placeholder="Enter text here" />
+          </FormControl>
+        </FormGroup>
+        <FormGroup>
+          <Label htmlFor="input9">Location</Label>
+          <FormControl>
+            <Input type="select" id="input9" name="selects" defaultValue="">
+              <option value="" disabled>Select a location</option>
+              <option value="option1">Option 1</option>
+              <option value="option2">Option 2</option>
+              <option value="option3">Option 3</option>
+            </Input>
+          </FormControl>
+        </FormGroup>
+        <FormGroup>
+          <Label htmlFor="input10">Upload a photo</Label>
+          <FormControl>
+            <Input type="file" id="input10" />
+          </FormControl>
+        </FormGroup>
+        <div className="u-align--right">
+          <Button positive type="submit">Register</Button>
+        </div>
+      </Form>),
+    ),
+  );

--- a/src/lib/components/Form/Form.test.js
+++ b/src/lib/components/Form/Form.test.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+import Form from './Form';
+import FormControl from './FormControl';
+import Input from '../Input/Input';
+import Label from '../Input/Label';
+
+describe('<Form>', () => {
+  it('should render with "form" tag', () => {
+    const form = shallow(<Form>Form</Form>);
+
+    expect(form.type()).toBe('form');
+  });
+
+  it('should render children', () => {
+    const form = shallow(<Form>Form</Form>);
+
+    expect(form.text()).toBe('Form');
+  });
+
+  it('should contain the inline form class if inline prop exists', () => {
+    const inlineClass = 'p-form--inline';
+    const form = shallow(<Form inline>Form</Form>);
+
+    expect(form.hasClass(inlineClass)).toBe(true);
+  });
+
+  it('should contain the stacked form class if inline prop exists', () => {
+    const inlineClass = 'p-form--stacked';
+    const form = shallow(<Form stacked>Form</Form>);
+
+    expect(form.hasClass(inlineClass)).toBe(true);
+  });
+
+  it('should render additional classes', () => {
+    const form = shallow(<Form className="class">Form</Form>);
+
+    expect(form.hasClass('class')).toBe(true);
+  });
+
+  it('should match snapshot of empty Form', () => {
+    const form = ReactTestRenderer.create(
+      <Form />);
+    const json = form.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should match snapshot of Form with Label and Input', () => {
+    const form = ReactTestRenderer.create(
+      <Form>
+        <Label htmlFor="input">Label</Label>
+        <Input id="input" />
+      </Form>);
+    const json = form.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should match snapshot of Form with FormControl', () => {
+    const form = ReactTestRenderer.create(
+      <Form>
+        <FormControl>
+          <Label htmlFor="input">Label</Label>
+          <Input id="input" />
+        </FormControl>
+      </Form>);
+    const json = form.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should match snapshot of Form with FormControl and help text', () => {
+    const form = ReactTestRenderer.create(
+      <Form>
+        <FormControl help="help text">
+          <Label htmlFor="input">Label</Label>
+          <Input id="input" />
+        </FormControl>
+      </Form>);
+    const json = form.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should match snapshot of Form with FormControl and validation', () => {
+    const form = ReactTestRenderer.create(
+      <Form>
+        <FormControl
+          validation={{
+            status: 'success',
+            tag: 'Success: ',
+            message: 'Validation message',
+          }}
+        >
+          <Label htmlFor="input">Label</Label>
+          <Input id="input" />
+        </FormControl>
+      </Form>);
+    const json = form.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/Form/FormControl.js
+++ b/src/lib/components/Form/FormControl.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+import FormHelpText from './FormHelpText';
+import Input from '../Input/Input';
+
+const FormControl = (props) => {
+  const {
+    children, className, help, validation,
+  } = props;
+
+  const classNames = getClassName({
+    'p-form__control': true,
+    'p-form-validation': validation.status,
+    [`is-${validation.status}`]: validation && validation.status,
+    [`${className}`]: className,
+  }) || undefined;
+
+  const formControlItems = React.Children.map(children, (child) => {
+    if (validation.status && child.type === Input) {
+      return React.cloneElement(child, { hasValidation: true });
+    }
+    return child;
+  });
+
+  return (
+    <div className={classNames}>
+      { formControlItems }
+      { validation.status && (
+        <p className="p-form-validation__message">
+          { validation.tag && <strong>{validation.tag}</strong> }
+          { validation.message }
+        </p>)
+      }
+      { help && <FormHelpText>{ help }</FormHelpText>}
+    </div>
+  );
+};
+
+FormControl.defaultProps = {
+  children: null,
+  className: undefined,
+  help: null,
+  validation: {
+    tag: null,
+    status: null,
+    message: null,
+  },
+};
+
+FormControl.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  help: PropTypes.node,
+  validation: PropTypes.shape({
+    tag: PropTypes.string,
+    status: PropTypes.oneOf([null, 'caution', 'success', 'error']),
+    message: PropTypes.node,
+  }),
+};
+
+FormControl.displayName = 'FormControl';
+
+export default FormControl;

--- a/src/lib/components/Form/FormControl.js
+++ b/src/lib/components/Form/FormControl.js
@@ -10,10 +10,10 @@ const FormControl = (props) => {
   } = props;
 
   const classNames = getClassName({
+    [className]: className,
     'p-form__control': true,
     'p-form-validation': validation.status,
     [`is-${validation.status}`]: validation && validation.status,
-    [`${className}`]: className,
   }) || undefined;
 
   const formControlItems = React.Children.map(children, (child) => {

--- a/src/lib/components/Form/FormGroup.js
+++ b/src/lib/components/Form/FormGroup.js
@@ -3,16 +3,15 @@ import PropTypes from 'prop-types';
 import getClassName from '../../utils/getClassName';
 
 const FormGroup = (props) => {
-  const { children } = props;
+  const { children, className } = props;
 
-  const customClasses = props.className;
-  const className = getClassName({
+  const classNames = getClassName({
+    [className]: className,
     'p-form__group': true,
-    [`${customClasses}`]: customClasses,
   }) || undefined;
 
   return (
-    <div className={className}>
+    <div className={classNames}>
       { children }
     </div>
   );

--- a/src/lib/components/Form/FormGroup.js
+++ b/src/lib/components/Form/FormGroup.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+const FormGroup = (props) => {
+  const { children } = props;
+
+  const customClasses = props.className;
+  const className = getClassName({
+    'p-form__group': true,
+    [`${customClasses}`]: customClasses,
+  }) || undefined;
+
+  return (
+    <div className={className}>
+      { children }
+    </div>
+  );
+};
+
+FormGroup.defaultProps = {
+  children: undefined,
+  className: '',
+};
+
+FormGroup.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+FormGroup.displayName = 'FormGroup';
+
+export default FormGroup;

--- a/src/lib/components/Form/FormHelpText.js
+++ b/src/lib/components/Form/FormHelpText.js
@@ -6,8 +6,8 @@ const FormHelpText = (props) => {
   const { children, className } = props;
 
   const classNames = getClassName({
+    [className]: className,
     'p-form-help-text': true,
-    [`${className}`]: className,
   }) || undefined;
 
   return (

--- a/src/lib/components/Form/FormHelpText.js
+++ b/src/lib/components/Form/FormHelpText.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+const FormHelpText = (props) => {
+  const { children, className } = props;
+
+  const classNames = getClassName({
+    'p-form-help-text': true,
+    [`${className}`]: className,
+  }) || undefined;
+
+  return (
+    <p className={classNames}>{ children }</p>
+  );
+};
+
+FormHelpText.defaultProps = {
+  children: null,
+  className: undefined,
+};
+
+FormHelpText.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+FormHelpText.displayName = 'FormHelpText';
+
+export default FormHelpText;

--- a/src/lib/components/Form/__snapshots__/Form.test.js.snap
+++ b/src/lib/components/Form/__snapshots__/Form.test.js.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Form> should match snapshot of Form with FormControl 1`] = `
+<form
+  className="p-form"
+>
+  <div
+    className="p-form__control"
+  >
+    <label
+      className="p-form__label"
+      htmlFor="input"
+    >
+      Label
+    </label>
+    <input
+      className={undefined}
+      id="input"
+      type="text"
+    />
+  </div>
+</form>
+`;
+
+exports[`<Form> should match snapshot of Form with FormControl and help text 1`] = `
+<form
+  className="p-form"
+>
+  <div
+    className="p-form__control"
+  >
+    <label
+      className="p-form__label"
+      htmlFor="input"
+    >
+      Label
+    </label>
+    <input
+      className={undefined}
+      id="input"
+      type="text"
+    />
+    <p
+      className="p-form-help-text"
+    >
+      help text
+    </p>
+  </div>
+</form>
+`;
+
+exports[`<Form> should match snapshot of Form with FormControl and validation 1`] = `
+<form
+  className="p-form"
+>
+  <div
+    className="p-form__control p-form-validation is-success"
+  >
+    <label
+      className="p-form__label"
+      htmlFor="input"
+    >
+      Label
+    </label>
+    <input
+      className="p-form-validation__input"
+      id="input"
+      type="text"
+    />
+    <p
+      className="p-form-validation__message"
+    >
+      <strong>
+        Success: 
+      </strong>
+      Validation message
+    </p>
+  </div>
+</form>
+`;
+
+exports[`<Form> should match snapshot of Form with Label and Input 1`] = `
+<form
+  className="p-form"
+>
+  <label
+    className="p-form__label"
+    htmlFor="input"
+  >
+    Label
+  </label>
+  <input
+    className={undefined}
+    id="input"
+    type="text"
+  />
+</form>
+`;
+
+exports[`<Form> should match snapshot of empty Form 1`] = `
+<form
+  className="p-form"
+/>
+`;

--- a/src/lib/components/Input/Input.js
+++ b/src/lib/components/Input/Input.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+function inputTag(type) {
+  if (type === 'select') {
+    return 'select';
+  } else if (type === 'textarea') {
+    return 'textarea';
+  }
+  return 'input';
+}
+
+const Input = (props) => {
+  const {
+    className, hasValidation, type, ...otherProps
+  } = props;
+
+  const classNames = getClassName({
+    'p-form-validation__input': hasValidation,
+    [`${className}`]: className,
+  }) || undefined;
+
+  const Tag = inputTag(type);
+
+  return (
+    <Tag
+      className={classNames}
+      type={type}
+      {...otherProps}
+    />
+  );
+};
+
+Input.defaultProps = {
+  className: undefined,
+  type: 'text',
+  hasValidation: false,
+};
+
+Input.propTypes = {
+  className: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  type: PropTypes.oneOf([
+    'text', 'password', 'file', 'checkbox', 'radio', 'select', 'textarea', 'date',
+    'hidden', 'month', 'time', 'week', 'color', 'number', 'email', 'url', 'tel',
+  ]),
+  hasValidation: PropTypes.bool,
+};
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/src/lib/components/Input/Input.js
+++ b/src/lib/components/Input/Input.js
@@ -17,8 +17,8 @@ const Input = (props) => {
   } = props;
 
   const classNames = getClassName({
+    [className]: className,
     'p-form-validation__input': hasValidation,
-    [`${className}`]: className,
   }) || undefined;
 
   const Tag = inputTag(type);

--- a/src/lib/components/Input/Input.stories.js
+++ b/src/lib/components/Input/Input.stories.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text, boolean, select } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import Input from './Input';
+import Label from './Label';
+import Button from '../Button/Button';
+import Form from '../Form/Form';
+
+const inputTypes = [
+  'text', 'password', 'file', 'hidden', 'date', 'month',
+  'time', 'week', 'number', 'email', 'url', 'tel',
+];
+
+const exampleSubmit = (event) => {
+  event.preventDefault();
+  alert('You submitted the form!'); // eslint-disable-line no-alert
+};
+
+storiesOf('Input', module)
+  .add('Standard inputs',
+    withInfo('Vanilla <Input> components support most HTML5 input types: text, password, file, hidden, date, month, time, week, number, email, url and tel. Note that a dummy submit function has been provided to prevent the page refreshing.')(() => (
+      <Form onSubmit={exampleSubmit}>
+        <Label htmlFor="textInput1">{text('Label', 'HTML5 input')}</Label>
+        <Input
+          type={select('Input type', inputTypes, 'text')}
+          id="textInput1"
+          placeholder={text('Placeholder', 'Placeholder')}
+          maxLength={text('Max length', '')}
+          required={boolean('Required', false)}
+          disabled={boolean('Disabled', false)}
+        />
+        <Button neutral type="submit">Submit</Button>
+      </Form>),
+    ),
+  )
+
+  .add('Checkbox and Radio',
+    withInfo('Use checkboxes and radio buttons to select one or more options. Note that <Input> components are placed before <Label> components for checkboxes and radio buttons.')(() => (
+      <Form onSubmit={exampleSubmit}>
+        <Input
+          type={select('Type1', ['checkbox', 'radio'], 'checkbox')}
+          id="input1"
+          required={boolean('Required1', false)}
+          disabled={boolean('Disabled1', false)}
+          name="inputs"
+        />
+        <Label htmlFor="input1">{text('Label1', 'Input 1')}</Label>
+        <Input
+          type={select('Type2', ['checkbox', 'radio'], 'checkbox')}
+          id="input2"
+          required={boolean('Required2', false)}
+          disabled={boolean('Disabled2', false)}
+          name="inputs"
+        />
+        <Label htmlFor="input2">{text('Label2', 'Input 2')}</Label>
+        <Button neutral type="submit">Submit</Button>
+      </Form>),
+    ),
+  )
+
+  .add('Textarea',
+    withInfo('An <Input> with type="textarea" defines a multi-line text input control.')(() => (
+      <Form onSubmit={exampleSubmit}>
+        <Label htmlFor="textareaInput1">Textarea</Label>
+        <Input
+          type="textarea"
+          id="textareaInput1"
+          placeholder={text('Placeholder', 'Placeholder')}
+          rows={text('Rows', '3')}
+          required={boolean('Required', false)}
+          disabled={boolean('Disabled', false)}
+        />
+        <Button neutral type="submit">Submit</Button>
+      </Form>),
+    ),
+  )
+
+  .add('Select',
+    withInfo('An <Input> with type="select" creates a drop-down list.')(() => (
+      <Form onSubmit={exampleSubmit}>
+        <Label htmlFor="selectInput1">Select</Label>
+        <Input
+          type="select"
+          id="selectInput1"
+          name="selectExample1"
+          required={boolean('Required', false)}
+          disabled={boolean('Disabled', false)}
+          defaultValue=""
+          multiple={boolean('Multiple', false)}
+        >
+          <option value="" disabled>Select an option</option>
+          <option value="1">{text('Option 1', 'Option 1')}</option>
+          <option value="2">{text('Option 2', 'Option 2')}</option>
+          <option value="3">{text('Option 3', 'Option 3')}</option>
+        </Input>
+        <Button neutral type="submit">Submit</Button>
+      </Form>),
+    ),
+  );

--- a/src/lib/components/Input/Input.test.js
+++ b/src/lib/components/Input/Input.test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+import Input from './Input';
+import Label from './Label';
+
+describe('<Input>', () => {
+  it('should match the default snapshot', () => {
+    const input = ReactTestRenderer.create(
+      <Input id="input" />);
+    const json = input.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render an input tag by default', () => {
+    const input = shallow(
+      <Input id="input" />,
+    );
+
+    expect(input.type()).toBe('input');
+  });
+
+  it('should render a select tag if type is "select"', () => {
+    const input = shallow(
+      <Input id="input" type="select" />,
+    );
+
+    expect(input.type()).toBe('select');
+  });
+
+  it('should render a textarea tag if type is "textarea"', () => {
+    const input = shallow(
+      <Input id="input" type="textarea" />,
+    );
+
+    expect(input.type()).toBe('textarea');
+  });
+
+  it('should render an input tag if type is not a special case', () => {
+    const input = shallow(
+      <Input id="input" type="password" />,
+    );
+
+    expect(input.type()).toBe('input');
+  });
+
+  it('should have appropriate validation class if hasValidation prop is true', () => {
+    const validationClass = 'p-form-validation__input';
+    const input = shallow(
+      <Input id="input" hasValidation />,
+    );
+
+    expect(input.hasClass(validationClass)).toBe(true);
+  });
+
+  it('should accept custom classnames', () => {
+    const input = shallow(
+      <Input id="input" className="custom-class" />,
+    );
+
+    expect(input.hasClass('custom-class')).toBe(true);
+  });
+});
+
+describe('<Label>', () => {
+  it('should match the default snapshot', () => {
+    const label = ReactTestRenderer.create(
+      <div>
+        <Input id="input" />
+        <Label htmlFor="input" />
+      </div>);
+    const json = label.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/lib/components/Input/Label.js
+++ b/src/lib/components/Input/Label.js
@@ -8,8 +8,8 @@ const Label = (props) => {
   } = props;
 
   const classNames = getClassName({
+    [className]: className,
     'p-form__label': true,
-    [`${className}`]: className,
   }) || undefined;
 
   return (

--- a/src/lib/components/Input/Label.js
+++ b/src/lib/components/Input/Label.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+const Label = (props) => {
+  const {
+    children, htmlFor, className, ...otherProps
+  } = props;
+
+  const classNames = getClassName({
+    'p-form__label': true,
+    [`${className}`]: className,
+  }) || undefined;
+
+  return (
+    <label className={classNames} htmlFor={htmlFor} {...otherProps}>{children}</label> // eslint-disable-line
+  );
+};
+
+Label.defaultProps = {
+  children: null,
+  className: undefined,
+};
+
+Label.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  htmlFor: PropTypes.string.isRequired,
+};
+
+Label.displayName = 'Label';
+
+export default Label;

--- a/src/lib/components/Input/__snapshots__/Input.test.js.snap
+++ b/src/lib/components/Input/__snapshots__/Input.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Input> should match the default snapshot 1`] = `
+<input
+  className={undefined}
+  id="input"
+  type="text"
+/>
+`;
+
+exports[`<Label> should match the default snapshot 1`] = `
+<div>
+  <input
+    className={undefined}
+    id="input"
+    type="text"
+  />
+  <label
+    className="p-form__label"
+    htmlFor="input"
+  />
+</div>
+`;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -9,12 +9,18 @@ import CodeBlock from './components/CodeBlock/CodeBlock';
 import CodeSnippet from './components/CodeSnippet/CodeSnippet';
 import DividerList from './components/DividerList/DividerList';
 import DividerListItem from './components/DividerList/DividerListItem';
+import Form from './components/Form/Form';
+import FormControl from './components/Form/FormControl';
+import FormGroup from './components/Form/FormGroup';
+import FormHelpText from './components/Form/FormHelpText';
 import Footer from './components/Footer/Footer';
 import FooterNav from './components/Footer/FooterNav';
 import FooterNavContainer from './components/Footer/FooterNavContainer';
 import HeadingIcon from './components/HeadingIcon/HeadingIcon';
 import Image from './components/Image/Image';
 import InlineImages from './components/InlineImages/InlineImages';
+import Input from './components/Input/Input';
+import Label from './components/Input/Label';
 import Link from './components/Link/Link';
 import List from './components/List/List';
 import ListItem from './components/List/ListItem';
@@ -51,10 +57,10 @@ import ToolTip from './components/ToolTip/ToolTip';
 
 export {
   Accordion, AccordionItem, BlockQuote, Breadcrumb, BreadcrumbItem, Button, Card, CodeBlock,
-  CodeSnippet, DividerList, DividerListItem, Footer, FooterNav, FooterNavContainer, HeadingIcon,
-  Image, InlineImages, Link, List, ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix,
-  MatrixItem, MediaObject, Modal, MutedHeading, Navigation, NavigationBanner, NavigationLink,
-  Notification, Pagination, PaginationItem, SideNav, SideNavBanner, SideNavGroup, SideNavLink,
-  SteppedList, SteppedListItem, Strip, StripColumn, StripRow, Switch, Table, TableCell, TableRow,
-  Tabs, TabsItem, ToolTip,
+  CodeSnippet, DividerList, DividerListItem, Form, FormControl, FormGroup, FormHelpText, Footer,
+  FooterNav, FooterNavContainer, HeadingIcon, Image, InlineImages, Input, Label, Link, List,
+  ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix, MatrixItem, MediaObject, Modal,
+  MutedHeading, Navigation, NavigationBanner, NavigationLink, Notification, Pagination,
+  PaginationItem, SideNav, SideNavBanner, SideNavGroup, SideNavLink, SteppedList, SteppedListItem,
+  Strip, StripColumn, StripRow, Switch, Table, TableCell, TableRow, Tabs, TabsItem, ToolTip,
 };

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -9,6 +9,7 @@ import CodeBlock from './components/CodeBlock/CodeBlock';
 import CodeSnippet from './components/CodeSnippet/CodeSnippet';
 import DividerList from './components/DividerList/DividerList';
 import DividerListItem from './components/DividerList/DividerListItem';
+import FieldSet from './components/Form/FieldSet';
 import Form from './components/Form/Form';
 import FormControl from './components/Form/FormControl';
 import FormGroup from './components/Form/FormGroup';
@@ -57,8 +58,8 @@ import ToolTip from './components/ToolTip/ToolTip';
 
 export {
   Accordion, AccordionItem, BlockQuote, Breadcrumb, BreadcrumbItem, Button, Card, CodeBlock,
-  CodeSnippet, DividerList, DividerListItem, Form, FormControl, FormGroup, FormHelpText, Footer,
-  FooterNav, FooterNavContainer, HeadingIcon, Image, InlineImages, Input, Label, Link, List,
+  CodeSnippet, DividerList, DividerListItem, FieldSet, Form, FormControl, FormGroup, FormHelpText,
+  Footer, FooterNav, FooterNavContainer, HeadingIcon, Image, InlineImages, Input, Label, Link, List,
   ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix, MatrixItem, MediaObject, Modal,
   MutedHeading, Navigation, NavigationBanner, NavigationLink, Notification, Pagination,
   PaginationItem, SideNav, SideNavBanner, SideNavGroup, SideNavLink, SteppedList, SteppedListItem,


### PR DESCRIPTION
## Done

- Added Form component and FieldSet, FormControl, FormGroup, and FormHelpText subcomponents
- Added Input component and Label subcomponent
- Added Storybook stories for Form and Input components
- Added basic snapshot and enzyme tests to Form and Input components
- Fixed issue with Button component not being able to accept "type" prop (basically I finally get the point of the "..." spread operator for React props, so should include it with the other components at some stage)
- Updated Storybook to Vanilla 1.6.6

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8102/](http://0.0.0.0:8102/)
- Check that the Input component operates as you would expect it to according to the [Vanilla docs](https://docs.vanillaframework.io/en/base/forms)
- Play around with the knobs panel and see how you can interact with the Input/Label components, and whether the props API works nicely
- Check that the base Form component operates as you would expect it to according to the [Vanilla docs](https://docs.vanillaframework.io/en/base/forms)
- Check that different layout Form components operate as you would expect them to according to the [Vanilla docs](https://docs.vanillaframework.io/en/patterns/forms)
- Play around with the knobs panel and see how you can interact with the Form component + subcomponents, and whether the props API works nicely
- Check the "Validation example" works as expected ([docs reference](https://docs.vanillaframework.io/en/patterns/form-validation))
- Check that Vanilla 1.6.6 has been implemented (go to Navigation and see if one of the tabs visually displays the "selected" tab)


## Issue / Card

Fixes #101, fixes #102 