### PR TITLE
107: Add 'expandable' and 'accordion' props to Table component

### DIFF
--- a/src/lib/components/Table/Table.js
+++ b/src/lib/components/Table/Table.js
@@ -252,6 +252,7 @@ class Table extends React.Component {
     return (
       <TableCell
         expandedCell
+        style={{ borderTop: '0' }}
         className={classNames}
         aria-hidden={!expandedCell || !isExpanded}
       >

--- a/src/lib/components/Table/Table.stories.js
+++ b/src/lib/components/Table/Table.stories.js
@@ -11,23 +11,21 @@ import MediaObject from '../MediaObject/MediaObject';
 const ExpandedCellExample = (props) => {
   const { name, location } = props; // eslint-disable-line
   return (
-    <div className="p-strip is-shallow">
-      <div className="row">
-        <div className="col-6 prefix-1">
-          <MediaObject
-            round
-            img={{ src: 'http://placehold.it/120x120', alt: '' }}
-            title={{ name }}
-            description="Lorem ipsum dolor sit amet"
-            metadata={{ location }}
-          />
-        </div>
-        <div className="col-4">
-          <h3>About me</h3>
-          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta
-            nostrum eligendi similique earum.
-          </p>
-        </div>
+    <div className="row" style={{ padding: '0.25rem 0' }}>
+      <div className="col-4">
+        <MediaObject
+          round
+          img={{ src: 'http://placehold.it/120x120', alt: '' }}
+          title={{ name }}
+          description="Lorem ipsum dolor sit amet"
+          metadata={{ location }}
+        />
+      </div>
+      <div className="col-4">
+        <h3>About me</h3>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta
+          nostrum eligendi similique earum.
+        </p>
       </div>
     </div>
   );

--- a/src/lib/components/Table/Table.stories.js
+++ b/src/lib/components/Table/Table.stories.js
@@ -6,6 +6,32 @@ import { withInfo } from '@storybook/addon-info';
 import Table from './Table';
 import TableCell from './TableCell';
 import TableRow from './TableRow';
+import MediaObject from '../MediaObject/MediaObject';
+
+const ExpandedCellExample = (props) => {
+  const { name, location } = props; // eslint-disable-line
+  return (
+    <div className="p-strip is-shallow">
+      <div className="row">
+        <div className="col-6 prefix-1">
+          <MediaObject
+            round
+            img={{ src: 'http://placehold.it/120x120', alt: '' }}
+            title={{ name }}
+            description="Lorem ipsum dolor sit amet"
+            metadata={{ location }}
+          />
+        </div>
+        <div className="col-4">
+          <h3>About me</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta
+            nostrum eligendi similique earum.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 const columns = [
   [
@@ -19,6 +45,11 @@ const columns = [
     { key: 'users', label: 'Users', align: 'right' },
     { key: 'units', label: 'Units', align: 'right' },
     { key: 'revenue', label: 'Revenue', align: 'right' },
+  ],
+  [
+    { key: 'username', label: 'Username' },
+    { key: 'email', label: 'Email' },
+    { key: 'height', label: 'Height (cm)', align: 'right' },
   ],
 ];
 
@@ -37,6 +68,25 @@ const data = [
   }, {
     id: 2, name: 'Apple', users: 9, units: 17, revenue: '$120',
   }],
+  [{
+    id: 0,
+    username: 'aeinstein',
+    email: 'albert.einstein@yahoo.com',
+    height: 175,
+    expandedCell: <ExpandedCellExample name="Albert Einstein" location="Ulm, Germany" />,
+  }, {
+    id: 1,
+    username: 'shawking',
+    email: 'stephen.hawking@hotmail.com',
+    height: 183,
+    expandedCell: <ExpandedCellExample name="Stephen Hawking" location="Oxford, England" />,
+  }, {
+    id: 2,
+    username: 'mcurie',
+    email: 'marie.curie@gmail.com',
+    height: 158,
+    expandedCell: <ExpandedCellExample name="Marie Curie" location="Warsaw, Poland" />,
+  }],
 ];
 
 storiesOf('Table', module)
@@ -45,6 +95,8 @@ storiesOf('Table', module)
       <Table
         hasHeader={boolean('Header', true)}
         sortable={boolean('Sortable', false)}
+        expandable={boolean('Expandable', false)}
+        accordion={boolean('Accordion', false)}
       >
         <TableRow tableHeader>
           <TableCell columnHeader />
@@ -57,6 +109,22 @@ storiesOf('Table', module)
           <TableCell>Table cell</TableCell>
           <TableCell>Table cell</TableCell>
           <TableCell>111</TableCell>
+          <TableCell expandedCell>
+            <div className="row">
+              <div className="col-6">
+                <h3>Expanding table cell 1</h3>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum
+                dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates
+                architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur
+                alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem
+                perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.
+                </p>
+              </div>
+              <div className="col-6">
+                <img src="http://placehold.it/1024x325" alt="" />
+              </div>
+            </div>
+          </TableCell>
         </TableRow>
         <TableRow>
           <TableCell>Header row</TableCell>
@@ -69,6 +137,22 @@ storiesOf('Table', module)
           <TableCell>Table cell</TableCell>
           <TableCell>Table cell</TableCell>
           <TableCell>333</TableCell>
+          <TableCell expandedCell>
+            <div className="row">
+              <div className="col-6">
+                <h3>Expanding table cell 2</h3>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum
+                dicta beatae nostrum eligendi similique earum, dolorem fuga quis, sequi voluptates
+                architecto ipsa dolorum eaque rem expedita inventore voluptas odit aspernatur
+                alias molestias facere, eum accusamus dolor, assumenda. Eaque, id! Dolorem
+                perferendis reprehenderit eum, odio minima ad commodi earum non, iste suscipit.
+                </p>
+              </div>
+              <div className="col-6">
+                <img src="http://placehold.it/1024x325" alt="" />
+              </div>
+            </div>
+          </TableCell>
         </TableRow>
       </Table>),
     ),
@@ -86,7 +170,7 @@ storiesOf('Table', module)
   )
 
   .add('No Header',
-    withInfo('Tables can have the header row disabled.')(() => (
+    withInfo('<Table> components can have the header row disabled.')(() => (
       <Table
         hasHeader={boolean('Header', false)}
         sortable={boolean('Sortable', false)}
@@ -108,13 +192,26 @@ storiesOf('Table', module)
   )
 
   .add('Pre-sorted',
-    withInfo('A Table can be pre-sorted if a valid sortCondition prop is provided. For Object Tables the sortCondition object key is the column key. In Static Tables, it is column(index) e.g. { column0: ascending }')(() => (
+    withInfo('A Table can be pre-sorted if a valid "sortCondition" prop is provided. For an Object Table the sortCondition object key is the column key. In a Static Table, it is column(index) e.g. { column0: ascending }')(() => (
       <Table
         hasHeader={boolean('Header', true)}
         sortable={boolean('Sortable', true)}
         sortCondition={{ units: 'descending' }}
         columns={columns[1]}
         data={data[1]}
+      />),
+    ),
+  )
+
+  .add('Expandable',
+    withInfo('Adding the "expandable" prop to a Table will allow expanding and hidden TableCell components which take up the full width of the TableRow. To make a TableRow expandable in an Object Table, you must pass in valid JSX to the key "expandedCell" on the relevant object in the data array, e.g. { id: 0, name: "name", expandedCell: <div>Hello World</div>. For a Static Table you simply add <TableCell expandedCell> to the TableRow you want to have expanded content, and pass in valid JSX as children. Adding the "accordion" prop as well limits the Table to having maximum one TableRow expanded at a time.')(() => (
+      <Table
+        hasHeader={boolean('Header', true)}
+        sortable={boolean('Sortable', false)}
+        expandable={boolean('Expandable', true)}
+        accordion={boolean('Accordion', false)}
+        columns={columns[2]}
+        data={data[2]}
       />),
     ),
   );

--- a/src/lib/components/Table/Table.test.js
+++ b/src/lib/components/Table/Table.test.js
@@ -17,30 +17,50 @@ const columns = [
     { key: 'units', label: 'Units', align: 'right' },
     { key: 'revenue', label: 'Revenue', align: 'right' },
   ],
+  [
+    { key: 'username', label: 'Username' },
+    { key: 'email', label: 'Email' },
+    { key: 'height', label: 'Height (cm)', align: 'right' },
+  ],
 ];
 
 const data = [
   [{
     id: 0, header: 'Header row', column1: 'Table cell', column2: 'Table cell', column3: 111,
-  },
-  {
+  }, {
     id: 1, header: 'Header row', column1: 'Table cell', column2: 'Table cell', column3: 222,
-  },
-  {
+  }, {
     id: 2, header: 'Header row', column1: 'Table cell', column2: 'Table cell', column3: 333,
   }],
   [{
     id: 0, name: 'Grape', users: 8, units: 19, revenue: '$70',
-  },
-  {
+  }, {
     id: 1, name: 'Melon', users: 12, units: 23, revenue: '$99',
-  },
-  {
+  }, {
     id: 2, name: 'Apple', users: 9, units: 17, revenue: '$120',
+  }],
+  [{
+    id: 0,
+    username: 'aeinstein',
+    email: 'albert.einstein@yahoo.com',
+    height: 175,
+    expandedCell: 'Hello',
+  }, {
+    id: 1,
+    username: 'shawking',
+    email: 'stephen.hawking@hotmail.com',
+    height: 183,
+    expandedCell: 'Hello',
+  }, {
+    id: 2,
+    username: 'mcurie',
+    email: 'marie.curie@gmail.com',
+    height: 158,
+    expandedCell: 'Hello',
   }],
 ];
 
-describe('Table component', () => {
+describe('<Table>', () => {
   it('should render a static table correctly', () => {
     const table = ReactTestRenderer.create(
       <Table>
@@ -115,6 +135,18 @@ describe('Table component', () => {
         sortCondition={{ units: 'descending' }}
         columns={columns[1]}
         data={data[1]}
+      />,
+    );
+    const json = table.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render an expandable table correctly', () => {
+    const table = ReactTestRenderer.create(
+      <Table
+        expandable
+        columns={columns[2]}
+        data={data[2]}
       />,
     );
     const json = table.toJSON();

--- a/src/lib/components/Table/TableCell.js
+++ b/src/lib/components/Table/TableCell.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
 
 const TableCell = (props) => {
   const {
-    align, ariaSort, children, columnHeader, onClick, role, rowHeader,
+    align, ariaSort, children, className, columnHeader, role, rowHeader, ...otherProps
   } = props;
-  const className = align ? `u-align--${align}` : null;
+
+  const classNames = getClassName({
+    [className]: className,
+    [`u-align--${align}`]: align,
+  }) || undefined;
 
   if (columnHeader) {
     return (
@@ -13,8 +18,8 @@ const TableCell = (props) => {
         scope="col"
         role="columnheader"
         aria-sort={ariaSort}
-        className={className}
-        onClick={onClick}
+        className={classNames}
+        {...otherProps}
       >
         {children}
       </th>);
@@ -25,7 +30,8 @@ const TableCell = (props) => {
       <th
         scope="row"
         role="rowheader"
-        className={className}
+        className={classNames}
+        {...otherProps}
       >
         {children}
       </th>);
@@ -34,7 +40,8 @@ const TableCell = (props) => {
   return (
     <td
       role={role}
-      className={className}
+      className={classNames}
+      {...otherProps}
     >
       {children}
     </td>
@@ -45,8 +52,8 @@ TableCell.defaultProps = {
   align: null,
   ariaSort: 'none',
   children: null,
+  className: undefined,
   columnHeader: false,
-  onClick: null,
   role: 'gridcell',
   rowHeader: false,
 };
@@ -55,8 +62,8 @@ TableCell.propTypes = {
   align: PropTypes.string,
   ariaSort: PropTypes.string,
   children: PropTypes.node,
+  className: PropTypes.string,
   columnHeader: PropTypes.bool,
-  onClick: PropTypes.func,
   role: PropTypes.string,
   rowHeader: PropTypes.bool,
 };

--- a/src/lib/components/Table/TableRow.js
+++ b/src/lib/components/Table/TableRow.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const TableRow = (props) => {
-  const tableRow = (
-    <tr role="row">
-      {props.children}
+  const { children, ...otherProps } = props;
+
+  return (
+    <tr role="row" {...otherProps}>
+      {children}
     </tr>
   );
-
-  return tableRow;
 };
 
 TableRow.propTypes = {

--- a/src/lib/components/Table/__snapshots__/Table.test.js.snap
+++ b/src/lib/components/Table/__snapshots__/Table.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Table component should render a dynamic table correctly 1`] = `
+exports[`<Table> should render a dynamic table correctly 1`] = `
 <table
-  className={null}
+  className={undefined}
   role="grid"
 >
   <thead>
@@ -11,7 +11,7 @@ exports[`Table component should render a dynamic table correctly 1`] = `
     >
       <th
         aria-sort="none"
-        className={null}
+        className={undefined}
         onClick={null}
         role="columnheader"
         scope="col"
@@ -20,7 +20,7 @@ exports[`Table component should render a dynamic table correctly 1`] = `
       </th>
       <th
         aria-sort="none"
-        className={null}
+        className={undefined}
         onClick={null}
         role="columnheader"
         scope="col"
@@ -29,7 +29,7 @@ exports[`Table component should render a dynamic table correctly 1`] = `
       </th>
       <th
         aria-sort="none"
-        className={null}
+        className={undefined}
         onClick={null}
         role="columnheader"
         scope="col"
@@ -52,20 +52,20 @@ exports[`Table component should render a dynamic table correctly 1`] = `
       role="row"
     >
       <th
-        className={null}
+        className={undefined}
         role="rowheader"
         scope="row"
       >
         Header row
       </th>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
       </td>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
@@ -81,20 +81,20 @@ exports[`Table component should render a dynamic table correctly 1`] = `
       role="row"
     >
       <th
-        className={null}
+        className={undefined}
         role="rowheader"
         scope="row"
       >
         Header row
       </th>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
       </td>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
@@ -110,20 +110,20 @@ exports[`Table component should render a dynamic table correctly 1`] = `
       role="row"
     >
       <th
-        className={null}
+        className={undefined}
         role="rowheader"
         scope="row"
       >
         Header row
       </th>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
       </td>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
@@ -139,9 +139,9 @@ exports[`Table component should render a dynamic table correctly 1`] = `
 </table>
 `;
 
-exports[`Table component should render a headerless table correctly 1`] = `
+exports[`<Table> should render a headerless table correctly 1`] = `
 <table
-  className={null}
+  className={undefined}
   role="grid"
 >
   <tbody>
@@ -149,20 +149,20 @@ exports[`Table component should render a headerless table correctly 1`] = `
       role="row"
     >
       <th
-        className={null}
+        className={undefined}
         role="rowheader"
         scope="row"
       >
         Header row
       </th>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
       </td>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
@@ -178,20 +178,20 @@ exports[`Table component should render a headerless table correctly 1`] = `
       role="row"
     >
       <th
-        className={null}
+        className={undefined}
         role="rowheader"
         scope="row"
       >
         Header row
       </th>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
       </td>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
@@ -207,20 +207,20 @@ exports[`Table component should render a headerless table correctly 1`] = `
       role="row"
     >
       <th
-        className={null}
+        className={undefined}
         role="rowheader"
         scope="row"
       >
         Header row
       </th>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
       </td>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
@@ -236,9 +236,9 @@ exports[`Table component should render a headerless table correctly 1`] = `
 </table>
 `;
 
-exports[`Table component should render a pre-sorted table correctly 1`] = `
+exports[`<Table> should render a pre-sorted table correctly 1`] = `
 <table
-  className={null}
+  className={undefined}
   role="grid"
 >
   <thead>
@@ -247,7 +247,7 @@ exports[`Table component should render a pre-sorted table correctly 1`] = `
     >
       <th
         aria-sort="none"
-        className={null}
+        className={undefined}
         onClick={null}
         role="columnheader"
         scope="col"
@@ -288,7 +288,7 @@ exports[`Table component should render a pre-sorted table correctly 1`] = `
       role="row"
     >
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Melon
@@ -316,7 +316,7 @@ exports[`Table component should render a pre-sorted table correctly 1`] = `
       role="row"
     >
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Grape
@@ -344,7 +344,7 @@ exports[`Table component should render a pre-sorted table correctly 1`] = `
       role="row"
     >
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Apple
@@ -372,7 +372,7 @@ exports[`Table component should render a pre-sorted table correctly 1`] = `
 </table>
 `;
 
-exports[`Table component should render a sortable table correctly 1`] = `
+exports[`<Table> should render a sortable table correctly 1`] = `
 <table
   className="p-table--sortable"
   role="grid"
@@ -383,7 +383,7 @@ exports[`Table component should render a sortable table correctly 1`] = `
     >
       <th
         aria-sort="none"
-        className={null}
+        className={undefined}
         onClick={[Function]}
         role="columnheader"
         scope="col"
@@ -424,7 +424,7 @@ exports[`Table component should render a sortable table correctly 1`] = `
       role="row"
     >
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Grape
@@ -452,7 +452,7 @@ exports[`Table component should render a sortable table correctly 1`] = `
       role="row"
     >
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Melon
@@ -480,7 +480,7 @@ exports[`Table component should render a sortable table correctly 1`] = `
       role="row"
     >
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Apple
@@ -508,9 +508,9 @@ exports[`Table component should render a sortable table correctly 1`] = `
 </table>
 `;
 
-exports[`Table component should render a static table correctly 1`] = `
+exports[`<Table> should render a static table correctly 1`] = `
 <table
-  className={null}
+  className={undefined}
   role="grid"
 >
   <thead>
@@ -519,7 +519,7 @@ exports[`Table component should render a static table correctly 1`] = `
     >
       <th
         aria-sort="none"
-        className={null}
+        className={undefined}
         onClick={null}
         role="columnheader"
         scope="col"
@@ -528,7 +528,7 @@ exports[`Table component should render a static table correctly 1`] = `
       </th>
       <th
         aria-sort="none"
-        className={null}
+        className={undefined}
         onClick={null}
         role="columnheader"
         scope="col"
@@ -537,7 +537,7 @@ exports[`Table component should render a static table correctly 1`] = `
       </th>
       <th
         aria-sort="none"
-        className={null}
+        className={undefined}
         onClick={null}
         role="columnheader"
         scope="col"
@@ -560,20 +560,20 @@ exports[`Table component should render a static table correctly 1`] = `
       role="row"
     >
       <th
-        className={null}
+        className={undefined}
         role="rowheader"
         scope="row"
       >
         Header row
       </th>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
       </td>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
@@ -589,20 +589,20 @@ exports[`Table component should render a static table correctly 1`] = `
       role="row"
     >
       <th
-        className={null}
+        className={undefined}
         role="rowheader"
         scope="row"
       >
         Header row
       </th>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
       </td>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
@@ -618,20 +618,20 @@ exports[`Table component should render a static table correctly 1`] = `
       role="row"
     >
       <th
-        className={null}
+        className={undefined}
         role="rowheader"
         scope="row"
       >
         Header row
       </th>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
       </td>
       <td
-        className={null}
+        className={undefined}
         role="gridcell"
       >
         Table cell
@@ -641,6 +641,231 @@ exports[`Table component should render a static table correctly 1`] = `
         role="gridcell"
       >
         333
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`<Table> should render an expandable table correctly 1`] = `
+<table
+  className="p-table-expanding"
+  role="grid"
+>
+  <thead>
+    <tr
+      role="row"
+    >
+      <th
+        aria-sort="none"
+        className={undefined}
+        onClick={null}
+        role="columnheader"
+        scope="col"
+      >
+        Username
+      </th>
+      <th
+        aria-sort="none"
+        className={undefined}
+        onClick={null}
+        role="columnheader"
+        scope="col"
+      >
+        Email
+      </th>
+      <th
+        aria-sort="none"
+        className="u-align--right"
+        onClick={null}
+        role="columnheader"
+        scope="col"
+      >
+        Height (cm)
+      </th>
+      <th
+        aria-sort={null}
+        className="u-align--right"
+        role="columnheader"
+        scope="col"
+        style={
+          Object {
+            "flexGrow": "0.5",
+          }
+        }
+      >
+        Expand
+      </th>
+      <td
+        className="u-hide"
+        role="gridcell"
+      />
+    </tr>
+  </thead>
+  <tbody>
+    <tr
+      role="row"
+    >
+      <td
+        className={undefined}
+        role="gridcell"
+      >
+        aeinstein
+      </td>
+      <td
+        className={undefined}
+        role="gridcell"
+      >
+        albert.einstein@yahoo.com
+      </td>
+      <td
+        className="u-align--right"
+        role="gridcell"
+      >
+        175
+      </td>
+      <td
+        className="u-align--right"
+        role="gridcell"
+        style={
+          Object {
+            "flexGrow": "0.5",
+          }
+        }
+      >
+        <button
+          className="p-button--base"
+          disabled={false}
+          href={undefined}
+          onClick={[Function]}
+          style={
+            Object {
+              "padding": "0.5rem",
+            }
+          }
+        >
+          <i
+            className="p-icon--plus"
+          />
+        </button>
+      </td>
+      <td
+        aria-hidden={true}
+        className="p-table-expanding__panel u-hide"
+        expandedCell={true}
+        role="gridcell"
+      >
+        Hello
+      </td>
+    </tr>
+    <tr
+      role="row"
+    >
+      <td
+        className={undefined}
+        role="gridcell"
+      >
+        shawking
+      </td>
+      <td
+        className={undefined}
+        role="gridcell"
+      >
+        stephen.hawking@hotmail.com
+      </td>
+      <td
+        className="u-align--right"
+        role="gridcell"
+      >
+        183
+      </td>
+      <td
+        className="u-align--right"
+        role="gridcell"
+        style={
+          Object {
+            "flexGrow": "0.5",
+          }
+        }
+      >
+        <button
+          className="p-button--base"
+          disabled={false}
+          href={undefined}
+          onClick={[Function]}
+          style={
+            Object {
+              "padding": "0.5rem",
+            }
+          }
+        >
+          <i
+            className="p-icon--plus"
+          />
+        </button>
+      </td>
+      <td
+        aria-hidden={true}
+        className="p-table-expanding__panel u-hide"
+        expandedCell={true}
+        role="gridcell"
+      >
+        Hello
+      </td>
+    </tr>
+    <tr
+      role="row"
+    >
+      <td
+        className={undefined}
+        role="gridcell"
+      >
+        mcurie
+      </td>
+      <td
+        className={undefined}
+        role="gridcell"
+      >
+        marie.curie@gmail.com
+      </td>
+      <td
+        className="u-align--right"
+        role="gridcell"
+      >
+        158
+      </td>
+      <td
+        className="u-align--right"
+        role="gridcell"
+        style={
+          Object {
+            "flexGrow": "0.5",
+          }
+        }
+      >
+        <button
+          className="p-button--base"
+          disabled={false}
+          href={undefined}
+          onClick={[Function]}
+          style={
+            Object {
+              "padding": "0.5rem",
+            }
+          }
+        >
+          <i
+            className="p-icon--plus"
+          />
+        </button>
+      </td>
+      <td
+        aria-hidden={true}
+        className="p-table-expanding__panel u-hide"
+        expandedCell={true}
+        role="gridcell"
+      >
+        Hello
       </td>
     </tr>
   </tbody>

--- a/src/lib/components/Table/__snapshots__/Table.test.js.snap
+++ b/src/lib/components/Table/__snapshots__/Table.test.js.snap
@@ -690,12 +690,11 @@ exports[`<Table> should render an expandable table correctly 1`] = `
         scope="col"
         style={
           Object {
-            "flexGrow": "0.5",
+            "flexBasis": "4rem",
+            "flexGrow": "0",
           }
         }
-      >
-        Expand
-      </th>
+      />
       <td
         className="u-hide"
         role="gridcell"
@@ -729,7 +728,8 @@ exports[`<Table> should render an expandable table correctly 1`] = `
         role="gridcell"
         style={
           Object {
-            "flexGrow": "0.5",
+            "flexBasis": "4rem",
+            "flexGrow": "0",
           }
         }
       >
@@ -740,7 +740,8 @@ exports[`<Table> should render an expandable table correctly 1`] = `
           onClick={[Function]}
           style={
             Object {
-              "padding": "0.5rem",
+              "marginRight": "0.5rem",
+              "padding": "0",
             }
           }
         >
@@ -754,6 +755,11 @@ exports[`<Table> should render an expandable table correctly 1`] = `
         className="p-table-expanding__panel u-hide"
         expandedCell={true}
         role="gridcell"
+        style={
+          Object {
+            "borderTop": "0",
+          }
+        }
       >
         Hello
       </td>
@@ -784,7 +790,8 @@ exports[`<Table> should render an expandable table correctly 1`] = `
         role="gridcell"
         style={
           Object {
-            "flexGrow": "0.5",
+            "flexBasis": "4rem",
+            "flexGrow": "0",
           }
         }
       >
@@ -795,7 +802,8 @@ exports[`<Table> should render an expandable table correctly 1`] = `
           onClick={[Function]}
           style={
             Object {
-              "padding": "0.5rem",
+              "marginRight": "0.5rem",
+              "padding": "0",
             }
           }
         >
@@ -809,6 +817,11 @@ exports[`<Table> should render an expandable table correctly 1`] = `
         className="p-table-expanding__panel u-hide"
         expandedCell={true}
         role="gridcell"
+        style={
+          Object {
+            "borderTop": "0",
+          }
+        }
       >
         Hello
       </td>
@@ -839,7 +852,8 @@ exports[`<Table> should render an expandable table correctly 1`] = `
         role="gridcell"
         style={
           Object {
-            "flexGrow": "0.5",
+            "flexBasis": "4rem",
+            "flexGrow": "0",
           }
         }
       >
@@ -850,7 +864,8 @@ exports[`<Table> should render an expandable table correctly 1`] = `
           onClick={[Function]}
           style={
             Object {
-              "padding": "0.5rem",
+              "marginRight": "0.5rem",
+              "padding": "0",
             }
           }
         >
@@ -864,6 +879,11 @@ exports[`<Table> should render an expandable table correctly 1`] = `
         className="p-table-expanding__panel u-hide"
         expandedCell={true}
         role="gridcell"
+        style={
+          Object {
+            "borderTop": "0",
+          }
+        }
       >
         Hello
       </td>


### PR DESCRIPTION
## Done

- Added 'expandable' and 'accordion' functionality to Table component (both static and object)
- Added Expandable story and updated the Static story in Storybook
- Allows JSX tables and tables generated from a JS object to have expanded content. Styling is not the same as that found on https://docs.vanillaframework.io/en/patterns/table-expanding, but I feel this is neater (and I think table styling as a whole needs a proper Design/UX lookover)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8102/](http://0.0.0.0:8102/)
- Check that the Table component has an Expandable story, and see it in action
- Check that expanding works with the static table, and the object table
- Check that expanding works in conjunction with the sortable prop
- Play around with the knobs panel and see how you can interact with the Table component, and whether the props API works nicely

## Issue / Card

Fixes #107 