### PR TITLE
Add ContextualMenu component and subcompoents

### DIFF
--- a/src/lib/components/ContextualMenu/ContextualMenu.js
+++ b/src/lib/components/ContextualMenu/ContextualMenu.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+import ContextualMenuDropdown from './ContextualMenuDropdown';
+
+class ContextualMenu extends React.Component {
+  constructor() {
+    super();
+
+    this.toggleOpen = this.toggleOpen.bind(this);
+    this.state = { open: false };
+  }
+
+  toggleOpen() {
+    this.setState({ open: !this.state.open });
+  }
+
+  render() {
+    const {
+      className, children, id, position, ...otherProps
+    } = this.props;
+
+    const classNames = getClassName({
+      [className]: className,
+      'p-contextual-menu': true,
+      [`p-contextual-menu--${position}`]: position,
+    }) || undefined;
+
+    const toggle = React.Children.map(children, (child) => {
+      if (child.type !== ContextualMenuDropdown) {
+        return React.cloneElement(child, {
+          className: 'p-contextual-menu__toggle',
+          'aria-controls': id,
+          'aria-expanded': this.state.open,
+          'aria-haspopup': 'true',
+          role: 'link',
+          onClick: this.toggleOpen,
+          tabIndex: 0,
+        });
+      } else if (child.type === ContextualMenuDropdown) {
+        return React.cloneElement(child, {
+          id,
+          'aria-hidden': !this.state.open,
+        });
+      }
+      return child;
+    });
+
+    return (
+      <span
+        className={classNames}
+        {...otherProps}
+      >
+        {toggle}
+      </span>
+    );
+  }
+}
+
+ContextualMenu.defaultProps = {
+  children: null,
+  className: null,
+  position: null,
+};
+
+ContextualMenu.propTypes = {
+  children: (props, propName, componentName) => {
+    const prop = props[propName];
+    let error = null;
+    let count = 0;
+
+    React.Children.forEach(prop, (child) => {
+      if (child.type === ContextualMenuDropdown) {
+        count += 1;
+      }
+    });
+
+    if (count !== 1) {
+      error = new Error(`${componentName} should have exactly one "ContextualMenuDropdown" child.`);
+    }
+
+    return error;
+  },
+  className: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  position: PropTypes.oneOf(['left', 'center']),
+};
+
+ContextualMenu.displayName = 'ContextualMenu';
+
+export default ContextualMenu;

--- a/src/lib/components/ContextualMenu/ContextualMenu.stories.js
+++ b/src/lib/components/ContextualMenu/ContextualMenu.stories.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { select } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+
+import ContextualMenu from './ContextualMenu';
+import ContextualMenuDropdown from './ContextualMenuDropdown';
+import ContextualMenuGroup from './ContextualMenuGroup';
+import Button from '../Button/Button';
+import Link from '../Link/Link';
+
+storiesOf('ContextualMenu', module)
+  .add('Default',
+    withInfo('A ContextualMenu component can be wrapped around any component (button, link, navigation item etc.) to give it a secondary dropdown menu on click. One of the children must be a ContextualMenuDropdown that contains the links (or other elements) you would like to display. ContextualMenus must be given an "id" prop so the dropdown knows where in the DOM to appear, and it also accepts a "position" prop to determine which side of the element appears (default "right").')(() => (
+      <div style={{ paddingLeft: '5rem' }}>
+        <ContextualMenu id="menu" position={select('Position', [undefined, 'left', 'center'], undefined)}>
+          <Button neutral>Menu</Button>
+          <ContextualMenuDropdown>
+            <Link href="#a">Link 1</Link>
+            <Link href="#a">Link 2</Link>
+            <Link href="#a">Link 3</Link>
+          </ContextualMenuDropdown>
+        </ContextualMenu>
+      </div>),
+    ),
+  )
+
+  .add('Groups',
+    withInfo('Dropdown links can be grouped when placed inside a ContextualMenuGroup component, which separates groups by a dividing line.')(() => (
+      <div style={{ paddingLeft: '5rem' }}>
+        <ContextualMenu id="menu" position={select('Position', [undefined, 'left', 'center'], undefined)}>
+          <Button neutral>Groups</Button>
+          <ContextualMenuDropdown>
+            <ContextualMenuGroup>
+              <Link href="#a">Link 1</Link>
+              <Link href="#a">Link 2</Link>
+            </ContextualMenuGroup>
+            <ContextualMenuGroup>
+              <Link href="#a">Link 3</Link>
+              <Link href="#a">Link 4</Link>
+            </ContextualMenuGroup>
+          </ContextualMenuDropdown>
+        </ContextualMenu>
+      </div>),
+    ),
+  )
+
+  .add('Link',
+    withInfo('ContextualMenus can be applied to any element, including links within paragraph text.')(() => (
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Modi natus atque eligendi
+        deleniti hic, dolores veritatis reiciendis officiis illo, facere facilis accusamus
+        similique nulla nesciunt.&nbsp;
+        <ContextualMenu id="menu" position={select('Position', [undefined, 'left', 'center'], undefined)}>
+          <Link href="#a" onClick={() => null}>Nemo</Link>
+          <ContextualMenuDropdown>
+            <ContextualMenuGroup>
+              <Link href="#a">Learn more</Link>
+              <Link href="#a">Learn more</Link>
+            </ContextualMenuGroup>
+            <ContextualMenuGroup>
+              <Link href="#a">Home</Link>
+            </ContextualMenuGroup>
+          </ContextualMenuDropdown>
+        </ContextualMenu>
+        &nbsp;reprehenderit officia assumenda error enim. Recusandae
+        reiciendis ipsum, mollitia illo iusto excepturi alias dolore fugit eligendi nostrum, unde
+        architecto consequuntur similique quo! Maxime iusto facere, commodi iste fuga officiis.
+      </p>),
+    ),
+  );

--- a/src/lib/components/ContextualMenu/ContextualMenu.test.js
+++ b/src/lib/components/ContextualMenu/ContextualMenu.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+import ContextualMenu from './ContextualMenu';
+import ContextualMenuDropdown from './ContextualMenuDropdown';
+import ContextualMenuGroup from './ContextualMenuGroup';
+
+describe('<ContextualMenu>', () => {
+  it('should render a simple ContextualMenu correctly', () => {
+    const menu = ReactTestRenderer.create(
+      <ContextualMenu id="menu">
+        <div>Menu</div>
+        <ContextualMenuDropdown>
+          <a href="#a">Link 1</a>
+          <a href="#a">Link 2</a>
+          <a href="#a">Link 3</a>
+        </ContextualMenuDropdown>
+      </ContextualMenu>);
+    const json = menu.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render with position prop correctly', () => {
+    const menu = ReactTestRenderer.create(
+      <div>
+        <ContextualMenu id="menu" position="left">
+          <div>Menu</div>
+          <ContextualMenuDropdown>
+            <a href="#a">Link 1</a>
+            <a href="#a">Link 2</a>
+            <a href="#a">Link 3</a>
+          </ContextualMenuDropdown>
+        </ContextualMenu>
+        <ContextualMenu id="menu" position="center">
+          <div>Menu</div>
+          <ContextualMenuDropdown>
+            <a href="#a">Link 1</a>
+            <a href="#a">Link 2</a>
+            <a href="#a">Link 3</a>
+          </ContextualMenuDropdown>
+        </ContextualMenu>
+      </div>);
+    const json = menu.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render ContextualMenuGroups correctly', () => {
+    const menu = ReactTestRenderer.create(
+      <ContextualMenu id="menu" position="left">
+        <div>Menu</div>
+        <ContextualMenuDropdown>
+          <ContextualMenuGroup>
+            <a href="#a">Link 1</a>
+            <a href="#a">Link 2</a>
+          </ContextualMenuGroup>
+          <ContextualMenuGroup>
+            <a href="#a">Link 3</a>
+            <a href="#a">Link 4</a>
+          </ContextualMenuGroup>
+        </ContextualMenuDropdown>
+      </ContextualMenu>);
+    const json = menu.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should open the ContextualMenu when clicked', () => {
+    const menu = shallow(
+      <ContextualMenu id="menu">
+        <button>Menu</button>
+        <ContextualMenuDropdown>
+          <a href="#a">Link 1</a>
+          <a href="#a">Link 2</a>
+          <a href="#a">Link 3</a>
+        </ContextualMenuDropdown>
+      </ContextualMenu>);
+
+    expect(menu.find('[aria-expanded=true]')).toHaveLength(0);
+    expect(menu.find('[aria-hidden=true]')).toHaveLength(1);
+
+    menu.find('button').hostNodes().simulate('click');
+    expect(menu.find('[aria-expanded=true]')).toHaveLength(1);
+    expect(menu.find('[aria-hidden=true]')).toHaveLength(0);
+  });
+});

--- a/src/lib/components/ContextualMenu/ContextualMenuDropdown.js
+++ b/src/lib/components/ContextualMenu/ContextualMenuDropdown.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+import ContextualMenuGroup from './ContextualMenuGroup';
+
+const ContextualMenuDropdown = (props) => {
+  const { children, className, ...otherProps } = props;
+
+  const classNames = getClassName({
+    [className]: className,
+    'p-contextual-menu__dropdown': true,
+  }) || undefined;
+
+  const dropdownItems = React.Children.map(children, (child) => {
+    if (child.type !== ContextualMenuGroup) {
+      const childClasses = getClassName({
+        [child.props.className]: child.props.className,
+        'p-contextual-menu__link': true,
+      });
+      return React.cloneElement(child, {
+        className: childClasses,
+      });
+    }
+    return child;
+  });
+
+  return (
+    <span className={classNames} {...otherProps}>
+      { dropdownItems }
+    </span>
+  );
+};
+
+ContextualMenuDropdown.defaultProps = {
+  children: null,
+  className: null,
+};
+
+ContextualMenuDropdown.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+ContextualMenuDropdown.displayName = 'ContextualMenuDropdown';
+
+export default ContextualMenuDropdown;

--- a/src/lib/components/ContextualMenu/ContextualMenuGroup.js
+++ b/src/lib/components/ContextualMenu/ContextualMenuGroup.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
+
+const ContextualMenuGroup = (props) => {
+  const { children, className, ...otherProps } = props;
+
+  const classNames = getClassName({
+    [className]: className,
+    'p-contextual-menu__group': true,
+  }) || undefined;
+
+  const items = React.Children.map(children, (child) => {
+    const childClasses = getClassName({
+      [child.props.className]: child.props.className,
+      'p-contextual-menu__link': true,
+    });
+    return React.cloneElement(child, {
+      className: childClasses,
+    });
+  });
+
+  return (
+    <span className={classNames} {...otherProps}>
+      {items}
+    </span>
+  );
+};
+
+ContextualMenuGroup.defaultProps = {
+  children: null,
+  className: null,
+};
+
+ContextualMenuGroup.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+ContextualMenuGroup.displayName = 'ContextualMenuGroup';
+
+export default ContextualMenuGroup;

--- a/src/lib/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
+++ b/src/lib/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
@@ -1,0 +1,182 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ContextualMenu> should render ContextualMenuGroups correctly 1`] = `
+<span
+  className="p-contextual-menu p-contextual-menu--left"
+>
+  <div
+    aria-controls="menu"
+    aria-expanded={false}
+    aria-haspopup="true"
+    className="p-contextual-menu__toggle"
+    onClick={[Function]}
+    role="link"
+    tabIndex={0}
+  >
+    Menu
+  </div>
+  <span
+    aria-hidden={true}
+    className="p-contextual-menu__dropdown"
+    id="menu"
+  >
+    <span
+      className="p-contextual-menu__group"
+    >
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 1
+      </a>
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 2
+      </a>
+    </span>
+    <span
+      className="p-contextual-menu__group"
+    >
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 3
+      </a>
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 4
+      </a>
+    </span>
+  </span>
+</span>
+`;
+
+exports[`<ContextualMenu> should render a simple ContextualMenu correctly 1`] = `
+<span
+  className="p-contextual-menu"
+>
+  <div
+    aria-controls="menu"
+    aria-expanded={false}
+    aria-haspopup="true"
+    className="p-contextual-menu__toggle"
+    onClick={[Function]}
+    role="link"
+    tabIndex={0}
+  >
+    Menu
+  </div>
+  <span
+    aria-hidden={true}
+    className="p-contextual-menu__dropdown"
+    id="menu"
+  >
+    <a
+      className="p-contextual-menu__link"
+      href="#a"
+    >
+      Link 1
+    </a>
+    <a
+      className="p-contextual-menu__link"
+      href="#a"
+    >
+      Link 2
+    </a>
+    <a
+      className="p-contextual-menu__link"
+      href="#a"
+    >
+      Link 3
+    </a>
+  </span>
+</span>
+`;
+
+exports[`<ContextualMenu> should render with position prop correctly 1`] = `
+<div>
+  <span
+    className="p-contextual-menu p-contextual-menu--left"
+  >
+    <div
+      aria-controls="menu"
+      aria-expanded={false}
+      aria-haspopup="true"
+      className="p-contextual-menu__toggle"
+      onClick={[Function]}
+      role="link"
+      tabIndex={0}
+    >
+      Menu
+    </div>
+    <span
+      aria-hidden={true}
+      className="p-contextual-menu__dropdown"
+      id="menu"
+    >
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 1
+      </a>
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 2
+      </a>
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 3
+      </a>
+    </span>
+  </span>
+  <span
+    className="p-contextual-menu p-contextual-menu--center"
+  >
+    <div
+      aria-controls="menu"
+      aria-expanded={false}
+      aria-haspopup="true"
+      className="p-contextual-menu__toggle"
+      onClick={[Function]}
+      role="link"
+      tabIndex={0}
+    >
+      Menu
+    </div>
+    <span
+      aria-hidden={true}
+      className="p-contextual-menu__dropdown"
+      id="menu"
+    >
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 1
+      </a>
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 2
+      </a>
+      <a
+        className="p-contextual-menu__link"
+        href="#a"
+      >
+        Link 3
+      </a>
+    </span>
+  </span>
+</div>
+`;

--- a/src/lib/components/Link/Link.js
+++ b/src/lib/components/Link/Link.js
@@ -2,33 +2,49 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import getClassName from '../../utils/getClassName';
 
-const Link = (props) => {
-  const {
-    soft, strong, inverted, external, top,
-  } = props;
-  const customClasses = props.className;
-
-  const className = getClassName({
-    'p-link--soft': soft,
-    'p-link--strong': strong,
-    'p-link--inverted': inverted,
-    'p-link--external': external,
-    'p-top__link': top,
-    [`${customClasses}`]: customClasses,
-  });
-
-  if (top) {
-    return (
-      <div className="p-top">
-        <a href={props.href} className={className}>{props.children}</a>
-      </div>
-    );
+class Link extends React.Component {
+  constructor() {
+    super();
+    this.onClick = this.onClick.bind(this);
   }
 
-  return (
-    <a href={props.href} className={className}>{props.children}</a>
-  );
-};
+  onClick(event) {
+    const { onClick } = this.props;
+
+    if (onClick) {
+      event.preventDefault();
+      onClick(event);
+    }
+  }
+
+  render() {
+    const {
+      children, className, soft, strong, inverted, external, top, href,
+    } = this.props;
+
+    const classNames = getClassName({
+      [className]: className,
+      'p-link': true,
+      'p-link--soft': soft,
+      'p-link--strong': strong,
+      'p-link--inverted': inverted,
+      'p-link--external': external,
+      'p-top__link': top,
+    });
+
+    if (top) {
+      return (
+        <div className="p-top">
+          <a href={href} className={classNames} onClick={this.onClick}>{children}</a>
+        </div>
+      );
+    }
+
+    return (
+      <a href={href} className={classNames} onClick={this.onClick}>{children}</a>
+    );
+  }
+}
 
 Link.defaultProps = {
   className: '',
@@ -37,6 +53,7 @@ Link.defaultProps = {
   inverted: false,
   external: false,
   top: false,
+  onClick: null,
 };
 
 Link.propTypes = {
@@ -48,6 +65,7 @@ Link.propTypes = {
   inverted: PropTypes.bool,
   external: PropTypes.bool,
   top: PropTypes.bool,
+  onClick: PropTypes.func,
 };
 
 Link.displayName = 'Link';

--- a/src/lib/components/Link/__snapshots__/Link.test.js.snap
+++ b/src/lib/components/Link/__snapshots__/Link.test.js.snap
@@ -3,26 +3,30 @@
 exports[`Link component should accept modifiers correctly 1`] = `
 <div>
   <a
-    className="p-link--external"
+    className="p-link p-link--external"
     href="https://vanillaframework.io/"
+    onClick={[Function]}
   >
     External Link
   </a>
   <a
-    className="p-link--soft"
+    className="p-link p-link--soft"
     href="https://vanilla-framework.github.io/vanilla-framework-react/"
+    onClick={[Function]}
   >
     Soft Link
   </a>
   <a
-    className="p-link--strong"
+    className="p-link p-link--strong"
     href="https://vanilla-framework.github.io/vanilla-framework-react/"
+    onClick={[Function]}
   >
     Strong Link
   </a>
   <a
-    className="p-link--inverted"
+    className="p-link p-link--inverted"
     href="https://vanilla-framework.github.io/vanilla-framework-react/"
+    onClick={[Function]}
   >
     Inverted Link
   </a>
@@ -30,21 +34,24 @@ exports[`Link component should accept modifiers correctly 1`] = `
     className="p-top"
   >
     <a
-      className="p-top__link"
+      className="p-link p-top__link"
       href="https://vanilla-framework.github.io/vanilla-framework-react/"
+      onClick={[Function]}
     >
       Back to top
     </a>
   </div>
   <a
-    className="p-link--strong p-link--external"
+    className="p-link p-link--strong p-link--external"
     href="https://vanillaframework.io/"
+    onClick={[Function]}
   >
     External/Strong Link
   </a>
   <a
-    className="p-link--soft p-link--external"
+    className="p-link p-link--soft p-link--external"
     href="https://vanillaframework.io/"
+    onClick={[Function]}
   >
     External/Soft Link
   </a>
@@ -52,8 +59,9 @@ exports[`Link component should accept modifiers correctly 1`] = `
     className="p-top"
   >
     <a
-      className="p-link--strong p-top__link"
+      className="p-link p-link--strong p-top__link"
       href="https://vanilla-framework.github.io/vanilla-framework-react/"
+      onClick={[Function]}
     >
       Strong/Back to top Link
     </a>
@@ -63,8 +71,9 @@ exports[`Link component should accept modifiers correctly 1`] = `
 
 exports[`Link component should render a simple link correctly 1`] = `
 <a
-  className=""
+  className="p-link"
   href="https://vanilla-framework.github.io/vanilla-framework-react/"
+  onClick={[Function]}
 >
   Default Link
 </a>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,6 +7,9 @@ import Button from './components/Button/Button';
 import Card from './components/Card/Card';
 import CodeBlock from './components/CodeBlock/CodeBlock';
 import CodeSnippet from './components/CodeSnippet/CodeSnippet';
+import ContextualMenu from './components/ContextualMenu/ContextualMenu';
+import ContextualMenuDropdown from './components/ContextualMenu/ContextualMenuDropdown';
+import ContextualMenuGroup from './components/ContextualMenu/ContextualMenuGroup';
 import DividerList from './components/DividerList/DividerList';
 import DividerListItem from './components/DividerList/DividerListItem';
 import FieldSet from './components/Form/FieldSet';
@@ -60,11 +63,11 @@ import ToolTip from './components/ToolTip/ToolTip';
 
 export {
   Accordion, AccordionItem, BlockQuote, Breadcrumb, BreadcrumbItem, Button, Card, CodeBlock,
-  CodeSnippet, DividerList, DividerListItem, FieldSet, Form, FormControl, FormGroup, FormHelpText,
-  Footer, FooterNav, FooterNavContainer, HeadingIcon, Image, InlineImages, Input, Label, Link, List,
-  ListItem, ListTree, ListTreeGroup, ListTreeItem, Matrix, MatrixItem, MediaObject, Modal,
-  MutedHeading, Navigation, NavigationBanner, NavigationLink, Notification, Pagination,
-  PaginationItem, SideNav, SideNavBanner, SideNavGroup, SideNavLink, Slider, SliderInput,
-  SteppedList, SteppedListItem, Strip, StripColumn, StripRow, Switch, Table, TableCell, TableRow,
-  Tabs, TabsItem, ToolTip,
+  CodeSnippet, ContextualMenu, ContextualMenuDropdown, ContextualMenuGroup, DividerList,
+  DividerListItem, FieldSet, Form, FormControl, FormGroup, FormHelpText, Footer, FooterNav,
+  FooterNavContainer, HeadingIcon, Image, InlineImages, Input, Label, Link, List, ListItem,
+  ListTree, ListTreeGroup, ListTreeItem, Matrix, MatrixItem, MediaObject, Modal, MutedHeading,
+  Navigation, NavigationBanner, NavigationLink, Notification, Pagination, PaginationItem, SideNav,
+  SideNavBanner, SideNavGroup, SideNavLink, Slider, SliderInput, SteppedList, SteppedListItem,
+  Strip, StripColumn, StripRow, Switch, Table, TableCell, TableRow, Tabs, TabsItem, ToolTip,
 };


### PR DESCRIPTION
## Done

- Added ContextualMenu component and ContextualMenuDropdown + ContextualMenuGroup subcomponents
- Added Storybook stories for ContextualMenu
- Added basic snapshot and enzyme tests for ContextualMenu
- Updated Link component to accept custom onClick function for any instance when you don't want default behaviour (e.g. when you want a ContextualMenu to appear and not get redirected)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8102/](http://0.0.0.0:8102/)
- Check that the ContextualMenu component operates as you would expect it to according to the [Vanilla docs](https://docs.vanillaframework.io/en/patterns/contextual-menu)
- Play around with the knobs panel and see how you can interact with the ContextualMenu component, and whether the props API works nicely


## Issue / Card

Fixes #100 