### PR TITLE
Update Storybook and components to Vanilla 1.8.0

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.6.6.min.css" />
+<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.8.0.min.css" />

--- a/src/lib/components/Matrix/Matrix.js
+++ b/src/lib/components/Matrix/Matrix.js
@@ -14,7 +14,7 @@ class Matrix extends React.Component {
     const extraMatrixItems = [];
 
     for (let i = 0; i < emptyItemCount; i += 1) {
-      extraMatrixItems.push(<MatrixItem key={i} />);
+      extraMatrixItems.push(<MatrixItem key={i} className="u-hide--small" />);
     }
 
     return extraMatrixItems;

--- a/src/lib/components/Matrix/MatrixItem.js
+++ b/src/lib/components/Matrix/MatrixItem.js
@@ -1,22 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
 
 const MatrixItem = (props) => {
   const {
-    children, href, img, title,
+    children, className, href, img, title,
   } = props;
 
+  const classNames = getClassName({
+    [className]: className,
+    'p-matrix__item': true,
+  }) || undefined;
+
   return (
-    <li className="p-matrix__item">
+    <li className={classNames}>
       {img && <img className="p-matrix__img" src={img.src} alt={img.alt} />}
       <div className="p-matrix__content">
         {title &&
           <h3 className="p-matrix__title">
             {href ? <a className="p-matrix__link" href={href}>{title}</a> : title}
           </h3>}
-        <p className="p-matrix__desc">
+        <div className="p-matrix__desc">
           { children }
-        </p>
+        </div>
       </div>
     </li>
   );
@@ -24,6 +30,7 @@ const MatrixItem = (props) => {
 
 MatrixItem.defaultProps = {
   children: null,
+  className: undefined,
   href: '',
   img: null,
   title: '',
@@ -31,6 +38,7 @@ MatrixItem.defaultProps = {
 
 MatrixItem.propTypes = {
   children: PropTypes.node,
+  className: PropTypes.string,
   img: PropTypes.shape({
     src: PropTypes.string,
     alt: PropTypes.string,

--- a/src/lib/components/Matrix/__snapshots__/Matrix.test.js.snap
+++ b/src/lib/components/Matrix/__snapshots__/Matrix.test.js.snap
@@ -11,11 +11,11 @@ exports[`Matrix component should auto-fill to have a multiple of three MatrixIte
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
@@ -25,11 +25,11 @@ exports[`Matrix component should auto-fill to have a multiple of three MatrixIte
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
@@ -39,11 +39,11 @@ exports[`Matrix component should auto-fill to have a multiple of three MatrixIte
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
@@ -53,33 +53,33 @@ exports[`Matrix component should auto-fill to have a multiple of three MatrixIte
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>
@@ -107,33 +107,33 @@ exports[`Matrix component should convert title to link when href prop provided 1
           Title
         </a>
       </h3>
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>
@@ -152,11 +152,11 @@ exports[`Matrix component should render a Matrix with multiple MatrixItem correc
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
@@ -166,11 +166,11 @@ exports[`Matrix component should render a Matrix with multiple MatrixItem correc
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
@@ -180,11 +180,11 @@ exports[`Matrix component should render a Matrix with multiple MatrixItem correc
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
 </ul>
@@ -201,33 +201,33 @@ exports[`Matrix component should render a Matrix with one MatrixItem correctly 1
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>
@@ -250,33 +250,33 @@ exports[`Matrix component should render a title when title prop provided 1`] = `
       >
         Title
       </h3>
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>
@@ -309,33 +309,33 @@ exports[`Matrix component should render an image when img prop provided 1`] = `
           Title
         </a>
       </h3>
-      <p
+      <div
         className="p-matrix__desc"
       >
         description
-      </p>
+      </div>
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>
   </li>
   <li
-    className="p-matrix__item"
+    className="u-hide--small p-matrix__item"
   >
     <div
       className="p-matrix__content"
     >
       
-      <p
+      <div
         className="p-matrix__desc"
       />
     </div>

--- a/src/lib/components/MediaObject/MediaObject.js
+++ b/src/lib/components/MediaObject/MediaObject.js
@@ -1,108 +1,106 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import getClassName from '../../utils/getClassName';
 
-const MediaObject = (props) => {
-  let image;
-  let title;
-  let description;
-  let metadata;
+class MediaObject extends React.Component {
+  constructor() {
+    super();
 
-  if (props.img) {
-    image = (
-      <img
-        className={`p-media-object__image${props.round ? ' is-round' : ''}`}
-        src={props.img.src}
-        alt={props.img.alt}
-      />
-    );
+    this.generateMetadata = this.generateMetadata.bind(this);
   }
 
-  if (props.title) {
-    if (props.title.link) {
-      title = (
-        <h3 className="p-media-object__title">
-          <a href={props.title.link}>{props.title.name}</a>
-        </h3>
-      );
-    } else {
-      title = (
-        <h3 className="p-media-object__title">
-          {props.title.name}
-        </h3>
-      );
-    }
-  }
+  generateMetadata() {
+    const { metadata } = this.props;
 
-  if (props.description) {
-    description = (
-      <p className="p-media-object__content">
-        {props.description}
-      </p>
-    );
-  }
+    const metadataItems = metadata.map((item, index) => {
+      const { description, type } = item;
+      const key = `${type}${index}`;
+      const metadataClass = getClassName({
+        'p-media-object__meta-list-item': !type,
+        'p-media-object__meta-list-item--date': type === 'date',
+        'p-media-object__meta-list-item--location': type === 'location',
+        'p-media-object__meta-list-item--venue': type === 'venue',
+      }) || undefined;
 
-  if (props.metadata) {
-    const metadataItems = Object.keys(props.metadata).map((key) => {
-      if (key === 'topic') {
-        return (
-          <li key={key} className="p-media-object__meta-list-item">
-            {props.metadata[key]}
-          </li>
-        );
-      }
       return (
-        <li key={key} className={`p-media-object__meta-list-item--${key}`}>
-          {props.metadata[key]}
-        </li>
+        <li key={key} className={metadataClass}>{description}</li>
       );
     });
 
-    metadata = (
+    return (
       <ul className="p-media-object__meta-list">
         {metadataItems}
       </ul>
     );
   }
 
-  return (
-    <div className={props.large ? 'p-media-object--large' : 'p-media-object'}>
-      {image}
-      <div className="p-media-object__details">
-        {title}
-        {description}
-        {metadata}
+  render() {
+    const {
+      children, className, href, img, large, metadata, round, title,
+    } = this.props;
+
+    const containerClass = getClassName({
+      [className]: className,
+      'p-media-object': !large,
+      'p-media-object--large': large,
+    }) || undefined;
+
+    const imgClass = getClassName({
+      'p-media-object__image': true,
+      'is-round': round,
+    } || undefined);
+
+    return (
+      <div className={containerClass}>
+        {img &&
+          <img className={imgClass} src={img.src} alt={img.alt} />
+        }
+        <div className="p-media-object__details">
+          {title &&
+            <h3 className="p-media-object__title">
+              {href ? <a href={href}>{title}</a> : title}
+            </h3>
+          }
+          {children &&
+            <div className="p-media-object__content">
+              {children}
+            </div>
+          }
+          {metadata && this.generateMetadata()}
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 MediaObject.defaultProps = {
-  round: false,
+  children: undefined,
+  className: undefined,
+  href: undefined,
+  img: undefined,
   large: false,
-  img: null,
-  title: null,
-  description: null,
-  metadata: null,
+  metadata: undefined,
+  round: false,
+  title: undefined,
 };
 
 MediaObject.propTypes = {
-  round: PropTypes.bool,
-  large: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  href: PropTypes.string,
   img: PropTypes.shape({
-    src: PropTypes.string,
     alt: PropTypes.string,
+    src: PropTypes.string,
   }),
-  title: PropTypes.shape({
-    name: PropTypes.string,
-    link: PropTypes.string,
-  }),
-  description: PropTypes.string,
-  metadata: PropTypes.shape({
-    topic: PropTypes.string,
-    date: PropTypes.string,
-    venue: PropTypes.string,
-    location: PropTypes.string,
-  }),
+  large: PropTypes.bool,
+  metadata: PropTypes.arrayOf(
+    PropTypes.shape({
+      description: PropTypes.string,
+      type: PropTypes.string,
+    }),
+  ),
+  round: PropTypes.bool,
+  title: PropTypes.string,
 };
 
 MediaObject.displayName = 'MediaObject';

--- a/src/lib/components/MediaObject/MediaObject.stories.js
+++ b/src/lib/components/MediaObject/MediaObject.stories.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text, boolean } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 
 import MediaObject from './MediaObject';
+
+const metadataOptions = [undefined, 'date', 'location', 'venue'];
 
 storiesOf('Media Object', module)
   .add('Default',
@@ -11,16 +13,27 @@ storiesOf('Media Object', module)
       <MediaObject
         round={boolean('Round', false)}
         large={boolean('Large', false)}
+        href={text('href', '#')}
         img={{ src: text('Image', 'http://placehold.it/72x72'), alt: '' }}
-        title={{ name: text('Title', 'Event Title'), link: text('Link', '#') }}
-        description={text('Description', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')}
-        metadata={{
-          topic: text('Topic', 'CSS frameworks'),
-          date: text('Date', '21 - 23 February 2017'),
-          venue: text('Venue', 'Venue 360'),
-          location: text('Location', 'Santa Clara, CA'),
-        }}
-      />),
+        title={text('Title', 'Event Title')}
+        metadata={[
+          {
+            description: text('Metadata description', 'CSS frameworks'),
+            type: select('Metadata type', metadataOptions),
+          }, {
+            description: '21 - 23 February 2017',
+            type: 'date',
+          }, {
+            description: 'Venue 360',
+            type: 'venue',
+          }, {
+            description: 'Santa Clara, CA',
+            type: 'location',
+          },
+        ]}
+      >
+        <p>{text('Description', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')}</p>
+      </MediaObject>),
     ),
   )
 
@@ -30,15 +43,17 @@ storiesOf('Media Object', module)
         round={boolean('Round', true)}
         large={boolean('Large', false)}
         img={{ src: text('Image', 'http://placehold.it/72x72'), alt: '' }}
-        title={{ name: text('Title', 'Person Name'), link: text('Link', '#') }}
-        description={text('Description', 'Lorem ipsum dolor sit amet')}
-        metadata={{
-          topic: text('Topic'),
-          date: text('Date'),
-          venue: text('Venue'),
-          location: text('Location', 'London, UK'),
-        }}
-      />),
+        title={text('Title', 'Person Name')}
+        href={text('href', '#')}
+        metadata={[
+          {
+            description: text('Metadata description', 'London, UK'),
+            type: select('Metadata type', metadataOptions, 'location'),
+          },
+        ]}
+      >
+        <p>{text('Description', 'Lorem ipsum dolor sit amet')}</p>
+      </MediaObject>),
     ),
   )
 
@@ -48,14 +63,10 @@ storiesOf('Media Object', module)
         round={boolean('Round', false)}
         large={boolean('Large', true)}
         img={{ src: text('Image', 'http://placehold.it/96x96'), alt: '' }}
-        title={{ name: text('Title', 'Title'), link: text('Link') }}
-        description={text('Description', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')}
-        metadata={{
-          topic: text('Topic'),
-          date: text('Date'),
-          venue: text('Venue'),
-          location: text('Location'),
-        }}
-      />),
+        title={text('Title', 'Title')}
+        href={text('href', undefined)}
+      >
+        <p>{text('Description', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')}</p>
+      </MediaObject>),
     ),
   );

--- a/src/lib/components/MediaObject/MediaObject.test.js
+++ b/src/lib/components/MediaObject/MediaObject.test.js
@@ -13,11 +13,19 @@ describe('MediaObject component', () => {
 
   it('should render default style correctly', () => {
     const mediaObject = ReactTestRenderer.create(
-      <MediaObject
-        title={{ name: 'Event Title' }}
-        description="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua."
-      />,
+      <MediaObject title="Event Title">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </MediaObject>,
+    );
+    const json = mediaObject.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render title with link correctly', () => {
+    const mediaObject = ReactTestRenderer.create(
+      <MediaObject title="Event Title" href="#" />,
     );
     const json = mediaObject.toJSON();
     expect(json).toMatchSnapshot();
@@ -25,25 +33,7 @@ describe('MediaObject component', () => {
 
   it('should render large prop correctly', () => {
     const mediaObject = ReactTestRenderer.create(
-      <MediaObject
-        large
-        title={{ name: 'Event Title' }}
-        description="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua."
-      />,
-    );
-    const json = mediaObject.toJSON();
-    expect(json).toMatchSnapshot();
-  });
-
-  it('should render round prop correctly', () => {
-    const mediaObject = ReactTestRenderer.create(
-      <MediaObject
-        round
-        title={{ name: 'Event Title' }}
-        description="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua."
-      />,
+      <MediaObject large />,
     );
     const json = mediaObject.toJSON();
     expect(json).toMatchSnapshot();
@@ -51,24 +41,15 @@ describe('MediaObject component', () => {
 
   it('should render image correctly', () => {
     const mediaObject = ReactTestRenderer.create(
-      <MediaObject
-        img={{ src: 'http://placehold.it/72x72', alt: '' }}
-        title={{ name: 'Event Title', link: '#' }}
-        description="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua."
-      />,
+      <MediaObject img={{ src: 'http://placehold.it/72x72', alt: 'alt' }} />,
     );
     const json = mediaObject.toJSON();
     expect(json).toMatchSnapshot();
   });
 
-  it('should render title link correctly', () => {
+  it('should render round image correctly', () => {
     const mediaObject = ReactTestRenderer.create(
-      <MediaObject
-        title={{ name: 'Event Title', link: '#' }}
-        description="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua."
-      />,
+      <MediaObject round img={{ src: 'http://placehold.it/72x72', alt: 'alt' }} />,
     );
     const json = mediaObject.toJSON();
     expect(json).toMatchSnapshot();
@@ -77,15 +58,20 @@ describe('MediaObject component', () => {
   it('should render metadata correctly', () => {
     const mediaObject = ReactTestRenderer.create(
       <MediaObject
-        title={{ name: 'Event Title', link: '#' }}
-        description="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua."
-        metadata={{
-          topic: 'CSS frameworks',
-          date: '21 - 23 February 2017',
-          venue: 'Venue 360',
-          location: 'Santa Clara, CA',
-        }}
+        metadata={[
+          {
+            description: 'CSS frameworks',
+          }, {
+            description: '21 - 23 February 2017',
+            type: 'date',
+          }, {
+            description: 'Venue 360',
+            type: 'venue',
+          }, {
+            description: 'Santa Clara, CA',
+            type: 'location',
+          },
+        ]}
       />,
     );
     const json = mediaObject.toJSON();
@@ -97,16 +83,27 @@ describe('MediaObject component', () => {
       <MediaObject
         round
         large
-        title={{ name: 'Event Title', link: '#' }}
-        description="Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua."
-        metadata={{
-          topic: 'CSS frameworks',
-          date: '21 - 23 February 2017',
-          venue: 'Venue 360',
-          location: 'Santa Clara, CA',
-        }}
-      />,
+        title="Event Title"
+        href="#"
+        metadata={[
+          {
+            description: 'CSS frameworks',
+          }, {
+            description: '21 - 23 February 2017',
+            type: 'date',
+          }, {
+            description: 'Venue 360',
+            type: 'venue',
+          }, {
+            description: 'Santa Clara, CA',
+            type: 'location',
+          },
+        ]}
+      >
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </MediaObject>,
     );
     const json = mediaObject.toJSON();
     expect(json).toMatchSnapshot();

--- a/src/lib/components/MediaObject/__snapshots__/MediaObject.test.js.snap
+++ b/src/lib/components/MediaObject/__snapshots__/MediaObject.test.js.snap
@@ -26,11 +26,13 @@ exports[`MediaObject component should render a MediaObject with several optional
         Event Title
       </a>
     </h3>
-    <p
+    <div
       className="p-media-object__content"
     >
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+    </div>
     <ul
       className="p-media-object__meta-list"
     >
@@ -71,11 +73,13 @@ exports[`MediaObject component should render default style correctly 1`] = `
     >
       Event Title
     </h3>
-    <p
+    <div
       className="p-media-object__content"
     >
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+    </div>
   </div>
 </div>
 `;
@@ -85,28 +89,13 @@ exports[`MediaObject component should render image correctly 1`] = `
   className="p-media-object"
 >
   <img
-    alt=""
+    alt="alt"
     className="p-media-object__image"
     src="http://placehold.it/72x72"
   />
   <div
     className="p-media-object__details"
-  >
-    <h3
-      className="p-media-object__title"
-    >
-      <a
-        href="#"
-      >
-        Event Title
-      </a>
-    </h3>
-    <p
-      className="p-media-object__content"
-    >
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </p>
-  </div>
+  />
 </div>
 `;
 
@@ -116,18 +105,7 @@ exports[`MediaObject component should render large prop correctly 1`] = `
 >
   <div
     className="p-media-object__details"
-  >
-    <h3
-      className="p-media-object__title"
-    >
-      Event Title
-    </h3>
-    <p
-      className="p-media-object__content"
-    >
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </p>
-  </div>
+  />
 </div>
 `;
 
@@ -138,20 +116,6 @@ exports[`MediaObject component should render metadata correctly 1`] = `
   <div
     className="p-media-object__details"
   >
-    <h3
-      className="p-media-object__title"
-    >
-      <a
-        href="#"
-      >
-        Event Title
-      </a>
-    </h3>
-    <p
-      className="p-media-object__content"
-    >
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </p>
     <ul
       className="p-media-object__meta-list"
     >
@@ -180,28 +144,22 @@ exports[`MediaObject component should render metadata correctly 1`] = `
 </div>
 `;
 
-exports[`MediaObject component should render round prop correctly 1`] = `
+exports[`MediaObject component should render round image correctly 1`] = `
 <div
   className="p-media-object"
 >
+  <img
+    alt="alt"
+    className="p-media-object__image is-round"
+    src="http://placehold.it/72x72"
+  />
   <div
     className="p-media-object__details"
-  >
-    <h3
-      className="p-media-object__title"
-    >
-      Event Title
-    </h3>
-    <p
-      className="p-media-object__content"
-    >
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </p>
-  </div>
+  />
 </div>
 `;
 
-exports[`MediaObject component should render title link correctly 1`] = `
+exports[`MediaObject component should render title with link correctly 1`] = `
 <div
   className="p-media-object"
 >
@@ -217,11 +175,6 @@ exports[`MediaObject component should render title link correctly 1`] = `
         Event Title
       </a>
     </h3>
-    <p
-      className="p-media-object__content"
-    >
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </p>
   </div>
 </div>
 `;

--- a/src/lib/components/Navigation/NavigationBanner.js
+++ b/src/lib/components/Navigation/NavigationBanner.js
@@ -14,7 +14,7 @@ class NavigationBanner extends React.Component {
         <div className="p-navigation__logo">
           <Tag className="p-navigation__link" href={href}>
             {(logo.src ?
-              <img className="p-navigation__image" src={logo.src} alt={logo.alt} /> : title
+              <img className="p-navigation__image" src={logo.src} alt={logo.alt} /> : <h3 style={{ margin: 0, alignSelf: 'center' }}>{title}</h3>
             )}
           </Tag>
         </div>

--- a/src/lib/components/Navigation/__snapshots__/Navigation.test.js.snap
+++ b/src/lib/components/Navigation/__snapshots__/Navigation.test.js.snap
@@ -55,7 +55,16 @@ exports[`<Navigation> renders with a single NavigationLink correctly 1`] = `
         className="p-navigation__link"
         href="#"
       >
-        Title
+        <h3
+          style={
+            Object {
+              "alignSelf": "center",
+              "margin": 0,
+            }
+          }
+        >
+          Title
+        </h3>
       </a>
     </div>
     <a
@@ -110,7 +119,16 @@ exports[`<Navigation> renders with a text-based NavigationBanner correctly 1`] =
         className="p-navigation__link"
         href="#"
       >
-        Title
+        <h3
+          style={
+            Object {
+              "alignSelf": "center",
+              "margin": 0,
+            }
+          }
+        >
+          Title
+        </h3>
       </a>
     </div>
     <a
@@ -146,7 +164,16 @@ exports[`<Navigation> renders with multiple NavigationLinks correctly 1`] = `
         className="p-navigation__link"
         href="#"
       >
-        Title
+        <h3
+          style={
+            Object {
+              "alignSelf": "center",
+              "margin": 0,
+            }
+          }
+        >
+          Title
+        </h3>
       </a>
     </div>
     <a

--- a/src/lib/components/Notification/Notification.js
+++ b/src/lib/components/Notification/Notification.js
@@ -2,38 +2,90 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import getClassName from '../../utils/getClassName';
 
-const Notification = (props) => {
-  const {
-    action, children, className, status, caution, information, negative, positive,
-  } = props;
+class Notification extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+    this.state = {
+      visible: props.visible,
+    };
+  }
 
-  const classNames = getClassName({
-    [className]: className,
-    'p-notification--information': information,
-    'p-notification--positive': positive,
-    'p-notification--caution': caution,
-    'p-notification--negative': negative,
-  }) || 'p-notification';
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.visible !== this.props.visible) {
+      this.setState({ visible: nextProps.visible });
+    }
+  }
 
-  return (
-    <div className={classNames}>
-      <p className="p-notification__response">
-        {status && <span className="p-notification__status">{status}</span>}
-        {children}
-        {action && <a href={action.href} className="p-notification__action">{action.value}</a>}
-      </p>
-    </div>
-  );
-};
+  handleClick(event) {
+    const { onClick } = this.props;
+    const { visible } = this.state;
+
+    if (onClick) {
+      onClick(event);
+    } else {
+      this.setState({ visible: !visible });
+    }
+  }
+
+  render() {
+    const {
+      action, children, className, dismissable, status, caution, information, negative, positive,
+      onClick,
+    } = this.props;
+    const { visible } = this.state;
+
+    // XXX Can remove when bug is fixed in Vanilla Sass
+    // https://github.com/vanilla-framework/vanilla-framework/issues/1928
+    const styleFix = {
+      backgroundColor: 'transparent',
+      backgroundSize: '1rem',
+      border: '0',
+      margin: '1.1875rem 1rem auto auto',
+      padding: '.5rem',
+    };
+
+    const classNames = getClassName({
+      [className]: className,
+      'p-notification--information': information,
+      'p-notification--positive': positive,
+      'p-notification--caution': caution,
+      'p-notification--negative': negative,
+    }) || 'p-notification';
+
+    return (
+      <div style={visible ? { display: 'flex' } : { display: 'none' }} className={classNames}>
+        <p className="p-notification__response">
+          {status && <span className="p-notification__status">{status}</span>}
+          {children}
+          {action && <a href={action.href} className="p-notification__action">{action.value}</a>}
+        </p>
+        {(dismissable || onClick) &&
+          <button
+            style={styleFix}
+            className="p-icon--close"
+            aria-label="Close notification"
+            onClick={this.handleClick}
+          >
+            Close
+          </button>
+        }
+      </div>
+    );
+  }
+}
 
 Notification.defaultProps = {
   action: null,
   caution: false,
   className: undefined,
+  dismissable: true,
   information: false,
   negative: false,
+  onClick: undefined,
   positive: false,
   status: null,
+  visible: true,
 };
 
 Notification.propTypes = {
@@ -44,10 +96,13 @@ Notification.propTypes = {
   caution: PropTypes.bool,
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  dismissable: PropTypes.bool,
   information: PropTypes.bool,
   negative: PropTypes.bool,
+  onClick: PropTypes.func,
   positive: PropTypes.bool,
   status: PropTypes.string,
+  visible: PropTypes.bool,
 };
 
 Notification.displayName = 'Notification';

--- a/src/lib/components/Notification/Notification.stories.js
+++ b/src/lib/components/Notification/Notification.stories.js
@@ -13,6 +13,7 @@ storiesOf('Notification', module)
         positive={boolean('Positive', false)}
         caution={boolean('Caution', false)}
         negative={boolean('Negative', false)}
+        visible={boolean('Visible', true)}
         status={text('Status', null)}
         action={{
           value: text('Action text', null),
@@ -31,6 +32,7 @@ storiesOf('Notification', module)
         positive={boolean('Positive', false)}
         caution={boolean('Caution', false)}
         negative={boolean('Negative', false)}
+        visible={boolean('Visible', true)}
         status={text('Status', 'Information:')}
         action={{
           value: text('Action text', null),
@@ -49,6 +51,7 @@ storiesOf('Notification', module)
         positive={boolean('Positive', true)}
         caution={boolean('Caution', false)}
         negative={boolean('Negative', false)}
+        visible={boolean('Visible', true)}
         status={text('Status', 'Success:')}
         action={{
           value: text('Action text', null),
@@ -67,6 +70,7 @@ storiesOf('Notification', module)
         positive={boolean('Positive', false)}
         caution={boolean('Caution', true)}
         negative={boolean('Negative', false)}
+        visible={boolean('Visible', true)}
         status={text('Status', 'Blocked:')}
         action={{
           value: text('Action text', null),
@@ -85,6 +89,7 @@ storiesOf('Notification', module)
         positive={boolean('Positive', false)}
         caution={boolean('Caution', false)}
         negative={boolean('Negative', true)}
+        visible={boolean('Visible', true)}
         status={text('Status', 'Error:')}
         action={{
           value: text('Action text', null),
@@ -103,9 +108,10 @@ storiesOf('Notification', module)
         positive={boolean('Positive', false)}
         caution={boolean('Caution', false)}
         negative={boolean('Negative', false)}
+        visible={boolean('Visible', true)}
         status={text('Status', null)}
         action={{
-          value: text('Action text', 'Dismiss'),
+          value: text('Action text', 'More information'),
           href: text('Action href', '#'),
         }}
       >

--- a/src/lib/components/Notification/__snapshots__/Notification.test.js.snap
+++ b/src/lib/components/Notification/__snapshots__/Notification.test.js.snap
@@ -3,54 +3,143 @@
 exports[`Notification component should render a caution Notification 1`] = `
 <div
   className="p-notification--caution"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
 >
   <p
     className="p-notification__response"
   >
     This is a caution Notification
   </p>
+  <button
+    aria-label="Close notification"
+    className="p-icon--close"
+    onClick={[Function]}
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundSize": "1rem",
+        "border": "0",
+        "margin": "1.1875rem 1rem auto auto",
+        "padding": ".5rem",
+      }
+    }
+  >
+    Close
+  </button>
 </div>
 `;
 
 exports[`Notification component should render a default Notification 1`] = `
 <div
   className="p-notification"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
 >
   <p
     className="p-notification__response"
   >
     This is a default Notification
   </p>
+  <button
+    aria-label="Close notification"
+    className="p-icon--close"
+    onClick={[Function]}
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundSize": "1rem",
+        "border": "0",
+        "margin": "1.1875rem 1rem auto auto",
+        "padding": ".5rem",
+      }
+    }
+  >
+    Close
+  </button>
 </div>
 `;
 
 exports[`Notification component should render a negative Notification 1`] = `
 <div
   className="p-notification--negative"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
 >
   <p
     className="p-notification__response"
   >
     This is a negative Notification
   </p>
+  <button
+    aria-label="Close notification"
+    className="p-icon--close"
+    onClick={[Function]}
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundSize": "1rem",
+        "border": "0",
+        "margin": "1.1875rem 1rem auto auto",
+        "padding": ".5rem",
+      }
+    }
+  >
+    Close
+  </button>
 </div>
 `;
 
 exports[`Notification component should render a positive Notification 1`] = `
 <div
   className="p-notification--positive"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
 >
   <p
     className="p-notification__response"
   >
     This is a positive Notification
   </p>
+  <button
+    aria-label="Close notification"
+    className="p-icon--close"
+    onClick={[Function]}
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundSize": "1rem",
+        "border": "0",
+        "margin": "1.1875rem 1rem auto auto",
+        "padding": ".5rem",
+      }
+    }
+  >
+    Close
+  </button>
 </div>
 `;
 
 exports[`Notification component should render a status if prop is provided 1`] = `
 <div
   className="p-notification"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
 >
   <p
     className="p-notification__response"
@@ -62,12 +151,33 @@ exports[`Notification component should render a status if prop is provided 1`] =
     </span>
     This is a Notification with a status
   </p>
+  <button
+    aria-label="Close notification"
+    className="p-icon--close"
+    onClick={[Function]}
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundSize": "1rem",
+        "border": "0",
+        "margin": "1.1875rem 1rem auto auto",
+        "padding": ".5rem",
+      }
+    }
+  >
+    Close
+  </button>
 </div>
 `;
 
 exports[`Notification component should render an action if prop is provided 1`] = `
 <div
   className="p-notification"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
 >
   <p
     className="p-notification__response"
@@ -80,17 +190,54 @@ exports[`Notification component should render an action if prop is provided 1`] 
       Action
     </a>
   </p>
+  <button
+    aria-label="Close notification"
+    className="p-icon--close"
+    onClick={[Function]}
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundSize": "1rem",
+        "border": "0",
+        "margin": "1.1875rem 1rem auto auto",
+        "padding": ".5rem",
+      }
+    }
+  >
+    Close
+  </button>
 </div>
 `;
 
 exports[`Notification component should render an information Notification 1`] = `
 <div
   className="p-notification--information"
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
 >
   <p
     className="p-notification__response"
   >
     This is an information Notification
   </p>
+  <button
+    aria-label="Close notification"
+    className="p-icon--close"
+    onClick={[Function]}
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundSize": "1rem",
+        "border": "0",
+        "margin": "1.1875rem 1rem auto auto",
+        "padding": ".5rem",
+      }
+    }
+  >
+    Close
+  </button>
 </div>
 `;

--- a/src/lib/components/Strip/Strip.stories.js
+++ b/src/lib/components/Strip/Strip.stories.js
@@ -208,10 +208,10 @@ storiesOf('Strip', module)
           <StripColumn size={6}>
             <h2>Ubuntu Enterprise Summit</h2>
             <h3>5 &mdash; 6 December 2017</h3>
-            <h5>Find out how the world&lsquo;s top companies use Ubuntu to succeed</h5>
-            <p>
+            <h4>Find out how the world&lsquo;s top companies use Ubuntu to succeed</h4>
+            <div>
               <Button positive value="Sign up now" />
-            </p>
+            </div>
           </StripColumn>
           <StripColumn size={6}>
             <Image src="https://assets.ubuntu.com/v1/9c1315fb-IOT_Ubuntu_devices_inforgrapic+v3.svg" alt="Ubuntu devices infographic" />

--- a/src/lib/components/Switch/Switch.js
+++ b/src/lib/components/Switch/Switch.js
@@ -1,45 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class Switch extends React.Component {
-  constructor() {
-    super();
-    this.switchToggle = this.switchToggle.bind(this);
-    this.state = {
-      checked: false,
-    };
-  }
+const Switch = (props) => {
+  const { checked, id, label } = props;
 
-  switchToggle() {
-    const { checked } = this.state;
-    this.setState({ checked: !checked });
-  }
+  return (
+    <label htmlFor={id}>
+      {label}
+      <input
+        id={id}
+        type="checkbox"
+        className="p-switch"
+        value={checked ? 'on' : 'off'}
+        checked={checked}
+      />
+      <div className="p-switch__slider" />
+    </label>
+  );
+};
 
-  render() {
-    const { checked } = this.state;
-    return (
-      <span>
-        <label id="switch-on-label" htmlFor="switch-on">{ this.props.label }
-          <button
-            id="switch-on"
-            className="p-switch"
-            type="button"
-            role="switch"
-            aria-checked={checked}
-            aria-labelledby="switch-on-label"
-            onClick={() => this.switchToggle(this)}
-          >
-            <span>On</span>
-            <span>Off</span>
-          </button>
-        </label>
-      </span>
-    );
-  }
-}
+Switch.defaultProps = {
+  checked: false,
+  label: undefined,
+};
 
 Switch.propTypes = {
-  label: PropTypes.string.isRequired,
+  checked: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string,
 };
 
 Switch.displayName = 'Switch';

--- a/src/lib/components/Switch/Switch.stories.js
+++ b/src/lib/components/Switch/Switch.stories.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { boolean, text } from '@storybook/addon-knobs';
 
 import Switch from './Switch';
 
 storiesOf('Switch', module)
   .add('Default',
     withInfo('You can use this switch pattern to display on and off content, such as for settings or simple controls. By changing the aria-checked attribute from true or false will animate the switch on/off.')(() =>
-      <Switch label="On/Off" />,
+      (<Switch
+        id="switch"
+        checked={boolean('Checked', false)}
+        label={text('Label', 'Switch')}
+      />),
     ),
   );

--- a/src/lib/components/Switch/Switch.test.js
+++ b/src/lib/components/Switch/Switch.test.js
@@ -5,7 +5,7 @@ import Switch from './Switch';
 describe('Switch component', () => {
   it('should compare with a snapshot', () => {
     const switchComponent = ReactTestRenderer.create(
-      <Switch label="Turn On/Off" />,
+      <Switch id="switch" label="Turn On/Off" />,
     );
     const json = switchComponent.toJSON();
     expect(json).toMatchSnapshot();

--- a/src/lib/components/Switch/__snapshots__/Switch.test.js.snap
+++ b/src/lib/components/Switch/__snapshots__/Switch.test.js.snap
@@ -1,28 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Switch component should compare with a snapshot 1`] = `
-<span>
-  <label
-    htmlFor="switch-on"
-    id="switch-on-label"
-  >
-    Turn On/Off
-    <button
-      aria-checked={false}
-      aria-labelledby="switch-on-label"
-      className="p-switch"
-      id="switch-on"
-      onClick={[Function]}
-      role="switch"
-      type="button"
-    >
-      <span>
-        On
-      </span>
-      <span>
-        Off
-      </span>
-    </button>
-  </label>
-</span>
+<label
+  htmlFor="switch"
+>
+  Turn On/Off
+  <input
+    checked={false}
+    className="p-switch"
+    id="switch"
+    type="checkbox"
+    value="off"
+  />
+  <div
+    className="p-switch__slider"
+  />
+</label>
 `;

--- a/src/lib/components/Table/Table.js
+++ b/src/lib/components/Table/Table.js
@@ -227,7 +227,7 @@ class Table extends React.Component {
           style={{ flexBasis: '4rem', flexGrow: '0' }}
         >
           {isExpandable ?
-            <Button style={{ marginRight: '0.5rem', padding: '0' }} onClick={() => this.handleExpand(row.id)}>
+            <Button style={{ padding: '0' }} onClick={() => this.handleExpand(row.id)}>
               <i className={isExpanded ? 'p-icon--minus' : 'p-icon--plus'} />
             </Button> :
             ''

--- a/src/lib/components/Table/Table.stories.js
+++ b/src/lib/components/Table/Table.stories.js
@@ -16,10 +16,10 @@ const ExpandedCellExample = (props) => {
         <MediaObject
           round
           img={{ src: 'http://placehold.it/120x120', alt: '' }}
-          title={{ name }}
-          description="Lorem ipsum dolor sit amet"
-          metadata={{ location }}
-        />
+          metadata={[{ type: 'location', description: location }]}
+        >
+          <p>Lorem ipsum dolor sit amet</p>
+        </MediaObject>
       </div>
       <div className="col-4">
         <h3>About me</h3>

--- a/src/lib/components/Table/__snapshots__/Table.test.js.snap
+++ b/src/lib/components/Table/__snapshots__/Table.test.js.snap
@@ -740,7 +740,6 @@ exports[`<Table> should render an expandable table correctly 1`] = `
           onClick={[Function]}
           style={
             Object {
-              "marginRight": "0.5rem",
               "padding": "0",
             }
           }
@@ -802,7 +801,6 @@ exports[`<Table> should render an expandable table correctly 1`] = `
           onClick={[Function]}
           style={
             Object {
-              "marginRight": "0.5rem",
               "padding": "0",
             }
           }
@@ -864,7 +862,6 @@ exports[`<Table> should render an expandable table correctly 1`] = `
           onClick={[Function]}
           style={
             Object {
-              "marginRight": "0.5rem",
               "padding": "0",
             }
           }


### PR DESCRIPTION
## Done

- Updated Storybook app to use Vanilla 1.8.0 and fixed associated visual bugs
- Fixed a bug where empty MatrixItems were displaying a small empty box instead of nothing
- Rewrote MediaObject to be a little more flexible and use new markup
- Fixed a small bug with NavigationBanner if using a text title instead of an image logo
- Added close button to Notification component
- Converted Switch component to the new checkbox version
- Fixed the MediaObject in the expandable Table component based on the changes made for 1.8.0
- Updated tests with Vanilla 1.8.0 changes (see #135)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8102/](http://0.0.0.0:8102/)
- Go through all the components and check that they look as they should in the [Vanilla examples](https://vanilla-framework.github.io/vanilla-framework/)
- Check that Matrix, Navigation, Notification, Switch and MediaObject function properly

## Issue / Card

Fixes #129 
